### PR TITLE
index bug in range and hex option

### DIFF
--- a/include/tts/detail/args.hpp
+++ b/include/tts/detail/args.hpp
@@ -30,7 +30,9 @@ namespace tts::detail
     std::string const &order()      const { return order_; }
     unsigned int       seed()       const { return seed_; }
     double             ulpmax()     const { return ulpmax_;}
-
+    bool               hex()        const { return hex_; 
+    }
+    
   private:
     mutable bool         disable_colors_;
     mutable bool         report_pass_;
@@ -40,6 +42,7 @@ namespace tts::detail
     mutable std::string  order_;
     mutable unsigned int seed_;
     mutable double       ulpmax_;
+    mutable bool         hex_; 
   };
 }
 

--- a/include/tts/detail/args.hpp
+++ b/include/tts/detail/args.hpp
@@ -30,8 +30,7 @@ namespace tts::detail
     std::string const &order()      const { return order_; }
     unsigned int       seed()       const { return seed_; }
     double             ulpmax()     const { return ulpmax_;}
-    bool               hex()        const { return hex_; 
-    }
+    bool               hex()        const { return hex_; }
     
   private:
     mutable bool         disable_colors_;

--- a/include/tts/tests/range.hpp
+++ b/include/tts/tests/range.hpp
@@ -75,8 +75,8 @@ namespace tts
     std::size_t size()      const noexcept { return self().size();   }
     static auto prng_seed()       noexcept { return args.seed();     }
     static auto count()           noexcept { return args.count();    }
-    static auto ulpmax()          noexcept { return args.ulpmax();   }
-    static auto hex()             noexcept { return args.hex();      }
+//     static auto ulpmax()          noexcept { return args.ulpmax();   }
+//     static auto hex()             noexcept { return args.hex();      }
 
         
 
@@ -234,7 +234,7 @@ namespace tts
       std::size_t last_bucket_ok = last_bucket_less(threshold);
       for(std::size_t i=0;i<histogram.size();++i)
       {
-        std::size_t tmp = display(i,q.size(),gs, q.hex());
+        std::size_t tmp = display(i,q.size(),gs, ::tts::args.hex());
         total += tmp;
         if(i <= last_bucket_ok) total_ok += tmp;
       }
@@ -329,7 +329,7 @@ namespace tts
                                                                                                     \
     ::tts::checker<local_tts_base_type, local_tts_resl_type> local_tts_checker;                     \
                                                                                                     \
-    double local_tts_threshold = ::tts::args.has_ulp() ? Producer.ulpmax() : Ulpmax;                \
+    double local_tts_threshold = ::tts::args.has_ulp() ? ::tts::args.ulpmax() : Ulpmax;             \
     double local_tts_max_ulp = local_tts_checker.run(Producer,RefFunc,NewFunc, TTS_STRING(RefFunc)  \
                                                     , TTS_STRING(NewFunc),local_tts_threshold);     \
                                                                                                     \
@@ -338,7 +338,14 @@ namespace tts
 /**/
 
 // Generate a range based test between two function
-#define TTS_RANGE_CHECK(Producer, Ref, New) TTS_ULP_RANGE_CHECK(Producer, Ref, New, 2.0)
+#define TTS_RANGE_CHECK(Producer, Ref, New)                                                         \
+  do                                                                                                \
+  {                                                                                                 \
+    if constexpr(is_floating_point_v(typename decltype(Producer)::value_type))                      \
+      TTS_ULP_RANGE_CHECK(Producer, Ref, New, 2.0)                                                  \
+    else                                                                                            \
+       TTS_ULP_RANGE_CHECK(Producer, Ref, New, 0)                                                   \
+} while(::tts::detail::is_false())                                                                  \  
 /**/
 
 #endif

--- a/include/tts/tests/range.hpp
+++ b/include/tts/tests/range.hpp
@@ -75,10 +75,6 @@ namespace tts
     std::size_t size()      const noexcept { return self().size();   }
     static auto prng_seed()       noexcept { return args.seed();     }
     static auto count()           noexcept { return args.count();    }
-//     static auto ulpmax()          noexcept { return args.ulpmax();   }
-//     static auto hex()             noexcept { return args.hex();      }
-
-        
 
     auto&       self()       noexcept { return static_cast<T&>(*this);        }
     auto const& self() const noexcept { return static_cast<T const&>(*this);  }
@@ -345,7 +341,7 @@ namespace tts
       TTS_ULP_RANGE_CHECK(Producer, Ref, New, 2.0)                                                  \
     else                                                                                            \
        TTS_ULP_RANGE_CHECK(Producer, Ref, New, 0)                                                   \
-} while(::tts::detail::is_false())                                                                  \  
+} while(::tts::detail::is_false())                                                                  \
 /**/
 
 #endif

--- a/include/tts/tests/range.hpp
+++ b/include/tts/tests/range.hpp
@@ -75,6 +75,10 @@ namespace tts
     std::size_t size()      const noexcept { return self().size();   }
     static auto prng_seed()       noexcept { return args.seed();     }
     static auto count()           noexcept { return args.count();    }
+//     static auto ulpmax()          noexcept { return args.ulpmax();   }
+//     static auto hex()             noexcept { return args.hex();      }
+
+        
 
     auto&       self()       noexcept { return static_cast<T&>(*this);        }
     auto const& self() const noexcept { return static_cast<T const&>(*this);  }
@@ -337,11 +341,11 @@ namespace tts
 #define TTS_RANGE_CHECK(Producer, Ref, New)                                                         \
   do                                                                                                \
   {                                                                                                 \
-    if constexpr(is_floating_point_v(typename decltype(Producer)::value_type))                      \
-      TTS_ULP_RANGE_CHECK(Producer, Ref, New, 2.0)                                                  \
+    if constexpr(std::is_floating_point_v<typename decltype(Producer)::value_type>)                 \
+      TTS_ULP_RANGE_CHECK(Producer, Ref, New, 2.0);                                                 \
     else                                                                                            \
-       TTS_ULP_RANGE_CHECK(Producer, Ref, New, 0)                                                   \
-} while(::tts::detail::is_false())                                                                  \
+      TTS_ULP_RANGE_CHECK(Producer, Ref, New, 0.0);                                                 \
+  } while(::tts::detail::is_false())                                                                \
 /**/
 
 #endif

--- a/include/tts/tests/range.hpp
+++ b/include/tts/tests/range.hpp
@@ -75,10 +75,6 @@ namespace tts
     std::size_t size()      const noexcept { return self().size();   }
     static auto prng_seed()       noexcept { return args.seed();     }
     static auto count()           noexcept { return args.count();    }
-//     static auto ulpmax()          noexcept { return args.ulpmax();   }
-//     static auto hex()             noexcept { return args.hex();      }
-
-        
 
     auto&       self()       noexcept { return static_cast<T&>(*this);        }
     auto const& self() const noexcept { return static_cast<T const&>(*this);  }

--- a/src/args.cpp
+++ b/src/args.cpp
@@ -26,6 +26,8 @@ namespace tts::detail
                         , order_{""}
                         , seed_{1}
                         , ulpmax_{2.0}
+                        , hex_{false}
+      
   {}
 
   TTS_API void args_map::update(int argc, char **argv) const
@@ -48,8 +50,11 @@ namespace tts::detail
                   ( "c,count"    , "Set size of experiments (default is 10000)"
                   , cxxopts::value<unsigned int>()
                   )
-                  ( "u,ulpmax"    , "Set global failure ulp threshold (default is 1.0)"
+                  ( "u,ulpmax"    , "Set global failure ulp threshold (default is 2.0)"
                   , cxxopts::value<double>()
+                  )
+                  ( "x,hex"    , "print the floating results in hexfloat mode"
+                  , cxxopts::value<bool>()
                   )
                   ( "h,help"      , "Display this help message");
 
@@ -79,6 +84,7 @@ namespace tts::detail
       auto now = std::chrono::high_resolution_clock::now();
       seed_ = static_cast<unsigned int>(now.time_since_epoch().count());
     }
+    if( result.count("hex")  ) hex_     = result["hex"].as<bool>();
   }
 }
 


### PR DESCRIPTION
encore un pb d'index dans range : possible overflow qui pouvait causer une boucle infinie
et option -x ou --hex qui affiche les valeurs en hexfloat