### PR TITLE
Address issue with clang capturee

### DIFF
--- a/src/tts/engine/logger.hpp
+++ b/src/tts/engine/logger.hpp
@@ -14,9 +14,23 @@ namespace tts
 {
   struct logger
   {
-    logger(bool status) : display(status), done(false) {}
+    logger(bool d = false) : display(d), done(false) {}
 
-    template<typename Data> logger& operator<<(Data&& d)
+    template<typename Result, typename Validator>
+    logger& check(Result const& res, Validator validate, auto pass, auto fail)
+    {
+      display = validate(res) ? pass(res) : fail(res);
+      return *this;
+    }
+
+    template<typename Result>
+    logger& check(Result const& res, auto pass, auto fail)
+    {
+      return check(res, [](auto const& r) { return static_cast<bool>(r); }, pass, fail);
+    }
+
+    template<typename Data>
+    logger& operator<<(Data const& d)
     {
       if(display)
       {
@@ -25,12 +39,10 @@ namespace tts
           std::cout << tts::yellow << ">> Additonnal information: " << ::tts::reset << "\n";
           done = true;
         }
-
         std::cout << d;
       }
       return *this;
     }
-
     bool display, done;
   };
 }

--- a/src/tts/test/basic.hpp
+++ b/src/tts/test/basic.hpp
@@ -13,50 +13,48 @@
 #include <tts/engine/logger.hpp>
 
 #define TTS_EXPECT_IMPL(EXPR,FAILURE)                                                               \
-[&]()                                                                                               \
-{                                                                                                   \
-  ::tts::result tts_var_d = TTS_DECOMPOSE(EXPR);                                                    \
-  if(tts_var_d)                                                                                     \
+::tts::logger{}.check                                                                               \
+( TTS_DECOMPOSE(EXPR)                                                                               \
+, [](tts::result const& res)                                                                        \
   {                                                                                                 \
     TTS_PASS( ::tts::green  << TTS_STRING(EXPR) << tts::reset                                       \
                             << " evaluates as " << ::tts::green                                     \
-                            << tts_var_d.lhs << " " << tts_var_d.op << " " << tts_var_d.rhs         \
+                            << res.lhs << " " << res.op << " " << res.rhs                           \
                             << ::tts::reset << " as expected.");                                    \
-    return ::tts::logger{false};                                                                    \
+    return false;                                                                                   \
   }                                                                                                 \
-  else                                                                                              \
+, [](tts::result const& res)                                                                        \
   {                                                                                                 \
     FAILURE ( "Expected: "  << ::tts::green << TTS_STRING(EXPR)  << tts::reset                      \
                             << " but " << ::tts::red                                                \
-                            << tts_var_d.lhs << " " << tts_var_d.op << " " << tts_var_d.rhs         \
+                            << res.lhs << " " << res.op << " " << res.rhs                           \
                             << ::tts::reset << " occured instead.");                                \
-    return ::tts::logger{::tts::verbose_status};                                                    \
+    return ::tts::verbose_status;                                                                   \
   }                                                                                                 \
-}()
+)                                                                                                   \
 /**/
 
 #define TTS_CONSTEXPR_EXPECT_IMPL(EXPR,FAILURE)                                                     \
-[&]()                                                                                               \
-{                                                                                                   \
-  ::tts::result tts_var_d = TTS_DECOMPOSE(EXPR);                                                    \
-  constexpr auto evaluation = std::bool_constant<(EXPR)>::value;                                    \
-  if(evaluation)                                                                                    \
+::tts::logger{}.check                                                                               \
+( TTS_DECOMPOSE(EXPR)                                                                               \
+, [](auto const&) { return std::bool_constant<(EXPR)>::value; }                                     \
+, [](::tts::result const& res)                                                                      \
   {                                                                                                 \
     TTS_PASS( ::tts::green  << TTS_STRING(EXPR) << tts::reset                                       \
                             << " evaluates as " << ::tts::green                                     \
-                            << tts_var_d.lhs << " " << tts_var_d.op << " " << tts_var_d.rhs         \
+                            << res.lhs << " " << res.op << " " << res.rhs                           \
                             << ::tts::reset << " at compile-time as expected.");                    \
-    return ::tts::logger{false};                                                                    \
+    return false;                                                                                   \
   }                                                                                                 \
-  else                                                                                              \
+, [](tts::result const& res)                                                                        \
   {                                                                                                 \
     FAILURE ( "Expected: "  << ::tts::green << TTS_STRING(EXPR)  << tts::reset                      \
                             << " but " << ::tts::red                                                \
-                            << tts_var_d.lhs << " " << tts_var_d.op << " " << tts_var_d.rhs         \
+                            << res.lhs << " " << res.op << " " << res.rhs                           \
                             << ::tts::reset << " occured at compile-time instead.");                \
-    return ::tts::logger{::tts::verbose_status};                                                    \
+    return ::tts::verbose_status;                                                                   \
   }                                                                                                 \
-}()
+)                                                                                                   \
 /**/
 
 #define TTS_EXPECT(EXPR, ...)     TTS_EXPECT_ ## __VA_ARGS__ ( EXPR )
@@ -68,52 +66,50 @@
 #define TTS_CONSTEXPR_EXPECT_REQUIRED(EXPR) TTS_CONSTEXPR_EXPECT_IMPL(EXPR,TTS_FATAL)
 
 #define TTS_EXPECT_NOT_IMPL(EXPR,FAILURE)                                                           \
-[&]()                                                                                               \
-{                                                                                                   \
-  ::tts::result tts_var_d = TTS_DECOMPOSE(EXPR);                                                    \
-  if(tts_var_d)                                                                                     \
+::tts::logger{}.check                                                                               \
+( TTS_DECOMPOSE(EXPR)                                                                               \
+, [](::tts::result res)                                                                             \
   {                                                                                                 \
     FAILURE ( "Expected: "  << ::tts::green << TTS_STRING(EXPR) << tts::reset                       \
                             << " to not evaluate to " << ::tts::red                                 \
-                            << tts_var_d.lhs << " " << tts_var_d.op << " " << tts_var_d.rhs         \
+                            << res.lhs << " " << res.op << " " << res.rhs                           \
                             << ::tts::reset << " but occured anyway."                               \
                             );                                                                      \
-    return ::tts::logger{::tts::verbose_status};                                                    \
+    return ::tts::verbose_status;                                                                   \
   }                                                                                                 \
-  else                                                                                              \
+, [](::tts::result res)                                                                             \
   {                                                                                                 \
     TTS_PASS ( ::tts::green << TTS_STRING(EXPR) << tts::reset                                       \
                             << " does not evaluate to " << ::tts::green                             \
-                            << tts_var_d.lhs << " " << tts_var_d.op << " " << tts_var_d.rhs         \
+                            << res.lhs << " " << res.op << " " << res.rhs                           \
                             << ::tts::reset << " as expected.");                                    \
-    return ::tts::logger{false};                                                                    \
+    return false;                                                                                   \
   }                                                                                                 \
-}()
+)                                                                                                   \
 /**/
 
 #define TTS_CONSTEXPR_EXPECT_NOT_IMPL(EXPR,FAILURE)                                                 \
-[&]()                                                                                               \
-{                                                                                                   \
-  ::tts::result tts_var_d = TTS_DECOMPOSE(EXPR);                                                    \
-  constexpr auto evaluation = std::bool_constant<(EXPR)>::value;                                    \
-  if(evaluation)                                                                                    \
+::tts::logger{}.check                                                                               \
+( TTS_DECOMPOSE(EXPR)                                                                               \
+, [](auto const&) { return std::bool_constant<(EXPR)>::value; }                                     \
+, [](tts::result const& res)                                                                        \
   {                                                                                                 \
     FAILURE ( "Expected: "  << ::tts::green << TTS_STRING(EXPR) << tts::reset                       \
                             << " to not evaluate to " << ::tts::red                                 \
-                            << tts_var_d.lhs << " " << tts_var_d.op << " " << tts_var_d.rhs         \
+                            << res.lhs << " " << res.op << " " << res.rhs                           \
                             << ::tts::reset << " at compile-time but occured anyway."               \
                             );                                                                      \
-    return ::tts::logger{::tts::verbose_status};                                                    \
+    return ::tts::verbose_status;                                                                   \
   }                                                                                                 \
-  else                                                                                              \
+, [](tts::result const& res)                                                                        \
   {                                                                                                 \
     TTS_PASS ( ::tts::green << TTS_STRING(EXPR) << tts::reset                                       \
                             << " does not evaluate to " << ::tts::green                             \
-                            << tts_var_d.lhs << " " << tts_var_d.op << " " << tts_var_d.rhs         \
+                            << res.lhs << " " << res.op << " " << res.rhs                           \
                             << ::tts::reset << " at compile-time as expected.");                    \
-    return ::tts::logger{false};                                                                    \
+    return false;                                                                                   \
   }                                                                                                 \
-}()
+)                                                                                                   \
 /**/
 
 #define TTS_EXPECT_NOT(EXPR, ...)     TTS_EXPECT_NOT_ ## __VA_ARGS__ ( EXPR )

--- a/src/tts/test/case.hpp
+++ b/src/tts/test/case.hpp
@@ -41,7 +41,7 @@ namespace tts::detail
 // Test case registration macros
 //==================================================================================================
 #define TTS_CASE_TPL(DESCRIPTION,...)                                                               \
-inline bool const TTS_CAT(register_,TTS_FUNCTION) =  ::tts::detail::lambda_test{                    \
+static bool const TTS_CAT(register_,TTS_FUNCTION) =  ::tts::detail::lambda_test{                    \
 [](auto tests)                                                                                      \
   {                                                                                                 \
     auto const single_test = [=]<typename T>( ::tts::type<T> )                                      \
@@ -66,7 +66,7 @@ inline bool const TTS_CAT(register_,TTS_FUNCTION) =  ::tts::detail::lambda_test{
 // Test case registration macros
 //==================================================================================================
 #define TTS_CASE(...)                                                                               \
-inline bool const TTS_CAT(register_,TTS_FUNCTION) =  ::tts::detail::lambda_test{                    \
+static bool const TTS_CAT(register_,TTS_FUNCTION) =  ::tts::detail::lambda_test{                    \
 [](auto tests)                                                                                      \
   {                                                                                                 \
     std::ostringstream title;                                                                       \

--- a/src/tts/test/decomposer.hpp
+++ b/src/tts/test/decomposer.hpp
@@ -22,7 +22,7 @@ namespace tts
   {
     bool        status;
     std::string lhs,op,rhs;
-    explicit operator bool() { return status; }
+    explicit operator bool() const { return status; }
   };
 
   // Carry value around up to display point inside test macro
@@ -33,7 +33,8 @@ namespace tts
     lhs_expr(lhs_expr const &)            = delete;
     lhs_expr &operator=(lhs_expr const &) = delete;
 
-    operator result() { return result {bool(lhs),as_string(bool(lhs)),"",""}; }
+    operator result() const { return result {bool(lhs),as_string(bool(lhs)),"",""}; }
+    explicit operator bool() const { return bool(lhs); }
 
     template<typename R> result operator &&(R const &rhs)
     {

--- a/src/tts/test/exceptions.hpp
+++ b/src/tts/test/exceptions.hpp
@@ -13,32 +13,27 @@
 #include <tts/engine/logger.hpp>
 
 #define TTS_THROW_IMPL(EXPR, EXCEPTION, FAILURE)                                                    \
-[&]()                                                                                               \
-{                                                                                                   \
-  bool tts_caught = false;                                                                          \
-                                                                                                    \
-  try                 { EXPR; }                                                                     \
-  catch(EXCEPTION&  ) { tts_caught = true; }                                                        \
-  catch(...)          { }                                                                           \
-                                                                                                    \
-  if(tts_caught)                                                                                    \
+::tts::logger{}.check                                                                               \
+( ::tts::result{}                                                                                   \
+, [&](auto const&) { try { EXPR; } catch(EXCEPTION&) { return true; } catch(...) {} return false; } \
+, [](auto const& res)                                                                               \
   {                                                                                                 \
     TTS_PASS( ::tts::green  << TTS_STRING(EXPR) << tts::reset                                       \
                             << " throws: " << ::tts::green                                          \
                             << TTS_STRING(EXCEPTION)                                                \
                             << ::tts::reset << " as expected."                                      \
             );                                                                                      \
-    return ::tts::logger{false};                                                                    \
+    return false;                                                                                   \
   }                                                                                                 \
-  else                                                                                              \
+, [](auto const& res)                                                                               \
   {                                                                                                 \
     FAILURE ( "Expected: "  << ::tts::green << TTS_STRING(EXPR)  << tts::reset                      \
                             << " failed to throw " << ::tts::red                                    \
                             << TTS_STRING(EXCEPTION)                                                \
             );                                                                                      \
-    return ::tts::logger{::tts::verbose_status};                                                    \
+    return ::tts::verbose_status;                                                                   \
   }                                                                                                 \
-}()
+)                                                                                                   \
 /**/
 
 #define TTS_THROW(EXPR, EXCEPTION, ...)     TTS_THROW_ ## __VA_ARGS__ ( EXPR, EXCEPTION )
@@ -46,28 +41,24 @@
 #define TTS_THROW_REQUIRED(EXPR, EXCEPTION) TTS_THROW_IMPL(EXPR, EXCEPTION,TTS_FATAL)
 
 #define TTS_NO_THROW_IMPL(EXPR,FAILURE)                                                             \
-[&]()                                                                                               \
-{                                                                                                   \
-  bool tts_caught = false;                                                                          \
-                                                                                                    \
-  try        { EXPR; }                                                                              \
-  catch(...) { tts_caught = true; }                                                                 \
-                                                                                                    \
-  if(!tts_caught)                                                                                   \
+::tts::logger{}.check                                                                               \
+( ::tts::result{}                                                                                   \
+, [&](auto const&) { try { EXPR; } catch(...) { return false; } return true; }                      \
+, [](auto const& res)                                                                               \
   {                                                                                                 \
     TTS_PASS( ::tts::green  << TTS_STRING(EXPR) << tts::reset                                       \
                             << " does not throw as expected."                                       \
             );                                                                                      \
-    return ::tts::logger{false};                                                                    \
+    return false;                                                                                   \
   }                                                                                                 \
-  else                                                                                              \
+, [](auto const& res)                                                                               \
   {                                                                                                 \
     FAILURE ( "Expected: "  << ::tts::red << TTS_STRING(EXPR)  << tts::reset                        \
                             << " throws unexpectedly."                                              \
             );                                                                                      \
-    return ::tts::logger{::tts::verbose_status};                                                    \
+    return ::tts::verbose_status;                                                                   \
   }                                                                                                 \
-}()
+)                                                                                                   \
 /**/
 
 #define TTS_NO_THROW(EXPR, ...)     TTS_NO_THROW_ ## __VA_ARGS__ ( EXPR )

--- a/src/tts/test/types.hpp
+++ b/src/tts/test/types.hpp
@@ -12,21 +12,19 @@
 #include <tts/tools/preprocessor.hpp>
 #include <tts/engine/logger.hpp>
 
-
 #define TTS_TYPE_IS_IMPL(T, TYPE, FAILURE)                                                          \
-[&]()                                                                                               \
-{                                                                                                   \
-  constexpr auto check = std::is_same_v<TTS_REMOVE_PARENS(TYPE), TTS_REMOVE_PARENS(T)>;             \
-                                                                                                    \
-  if constexpr(check)                                                                               \
+::tts::logger{}.check                                                                               \
+( ::tts::result{}                                                                                   \
+, [](auto const&) { return std::is_same_v<TTS_REMOVE_PARENS(TYPE), TTS_REMOVE_PARENS(T)>; }         \
+, [](auto const& res)                                                                               \
   {                                                                                                 \
     TTS_PASS( ::tts::green  << TTS_STRING(TTS_REMOVE_PARENS(T)) << tts::reset                       \
                             << " evaluates as " << ::tts::green                                     \
                             << tts::typename_<TTS_REMOVE_PARENS(TYPE)>                              \
                             << ::tts::reset << " as expected.");                                    \
-    return ::tts::logger{false};                                                                    \
+    return false;                                                                                   \
   }                                                                                                 \
-  else                                                                                              \
+, [](auto const& res)                                                                               \
   {                                                                                                 \
     FAILURE( ::tts::green  << TTS_STRING(TTS_REMOVE_PARENS(T)) << tts::reset                        \
                             << " evaluates as " << ::tts::red                                       \
@@ -34,9 +32,9 @@
                             << ::tts::reset << " instead of "                                       \
                             << ::tts::green << tts::typename_<TTS_REMOVE_PARENS(TYPE)>              \
             );                                                                                      \
-    return ::tts::logger{::tts::verbose_status};                                                    \
+    return ::tts::verbose_status;                                                                   \
   }                                                                                                 \
-}()
+)                                                                                                   \
 /**/
 
 #define TTS_TYPE_IS(T, TYPE, ...)     TTS_TYPE_IS_ ## __VA_ARGS__ ( T, TYPE )

--- a/test/basic/expect.cpp
+++ b/test/basic/expect.cpp
@@ -9,8 +9,9 @@
 
 TTS_CASE( "Check that expectation can be met" )
 {
-  int a = 43, b = 69;
+  auto[a,b] = std::make_pair(43,69);
 
+  TTS_EXPECT(a);
   TTS_EXPECT(a == a);
   TTS_EXPECT(a != b);
   TTS_EXPECT(a <  b);
@@ -20,6 +21,7 @@ TTS_CASE( "Check that expectation can be met" )
   TTS_EXPECT(a && b);
   TTS_EXPECT(a || b);
 
+  TTS_EXPECT(a     , REQUIRED);
   TTS_EXPECT(a == a, REQUIRED);
   TTS_EXPECT(a != b, REQUIRED);
   TTS_EXPECT(a <  b, REQUIRED);

--- a/test/basic/expect_not.cpp
+++ b/test/basic/expect_not.cpp
@@ -9,8 +9,9 @@
 
 TTS_CASE( "Check that counter-expectation can be met" )
 {
-  int a = 42, b = 69;
+  int a = 42, b = 69, v = 0;
 
+  TTS_EXPECT_NOT(v);
   TTS_EXPECT_NOT(a == b);
   TTS_EXPECT_NOT(a != a);
   TTS_EXPECT_NOT(a >  b);
@@ -20,6 +21,7 @@ TTS_CASE( "Check that counter-expectation can be met" )
   TTS_EXPECT_NOT(b && 0);
   TTS_EXPECT_NOT(0 || 0);
 
+  TTS_EXPECT_NOT(v     , REQUIRED);
   TTS_EXPECT_NOT(a != a, REQUIRED);
   TTS_EXPECT_NOT(a == b, REQUIRED);
   TTS_EXPECT_NOT(a >  b, REQUIRED);


### PR DESCRIPTION
Internals of TTS has been modified so testing value over structured bound names don't fail on clang.