### PR TITLE
Better compatibility

### DIFF
--- a/include/tts/tts.hpp
+++ b/include/tts/tts.hpp
@@ -473,18 +473,22 @@ namespace tts
 }(EXPR)                                                                                             \
 
 #define TTS_CONSTEXPR_EXPECT(EXPR)                                                                  \
-[&]()                                                                                               \
+[]<typename C>(C )                                                                                  \
 {                                                                                                   \
-  static_assert((EXPR), "[TTS] - Error: " TTS_STRING(EXPR) " evaluates to false at compile-time."); \
+  static_assert ( C::value                                                                          \
+                , "[TTS] - Error: " TTS_STRING(EXPR) " evaluates to false at compile-time."         \
+                );                                                                                  \
   ::tts::global_runtime.pass();                                                                     \
-}()                                                                                                 \
+}(std::bool_constant<EXPR>{})                                                                       \
 
 #define TTS_CONSTEXPR_EXPECT_NOT(EXPR)                                                              \
-[&]()                                                                                               \
+[]<typename C>(C )                                                                                  \
 {                                                                                                   \
-  static_assert(!(EXPR), "[TTS] - Error: " TTS_STRING(EXPR) " evaluates to true at compile-time."); \
+  static_assert ( !C::value                                                                         \
+                , "[TTS] - Error: " TTS_STRING(EXPR) " evaluates to true at compile-time."          \
+                );                                                                                  \
   ::tts::global_runtime.pass();                                                                     \
-}()                                                                                                 \
+}(std::bool_constant<EXPR>{})                                                                       \
 
 namespace tts::detail
 {

--- a/include/tts/tts.hpp
+++ b/include/tts/tts.hpp
@@ -706,10 +706,24 @@ namespace tts
 #include <cstdint>
 #include <type_traits>
 #include <utility>
+#if !defined(__cpp_lib_bit_cast)
+# include <cstring>
+#endif
 namespace tts::detail
 {
-  inline auto as_int(float a)   noexcept  { return std::bit_cast<std::int32_t>(a); }
-  inline auto as_int(double a)  noexcept  { return std::bit_cast<std::int64_t>(a); }
+#if !defined(__cpp_lib_bit_cast)
+  template <class To, class From>
+  To bit_cast(const From& src) noexcept requires(sizeof(To) == sizeof(From))
+  {
+    To dst;
+    std::memcpy(&dst, &src, sizeof(To));
+    return dst;
+  }
+#else
+  using std::bit_cast;
+#endif
+  inline auto as_int(float a)   noexcept  { return bit_cast<std::int32_t>(a); }
+  inline auto as_int(double a)  noexcept  { return bit_cast<std::int64_t>(a); }
   template<typename T> inline auto bitinteger(T a) noexcept
   {
     auto ia = as_int(a);

--- a/src/tts/test/basic.hpp
+++ b/src/tts/test/basic.hpp
@@ -50,17 +50,22 @@
 /**/
 
 #define TTS_CONSTEXPR_EXPECT(EXPR)                                                                  \
-[&]()                                                                                               \
+[]<typename C>(C )                                                                                  \
 {                                                                                                   \
-  static_assert((EXPR), "[TTS] - Error: " TTS_STRING(EXPR) " evaluates to false at compile-time."); \
+  static_assert ( C::value                                                                          \
+                , "[TTS] - Error: " TTS_STRING(EXPR) " evaluates to false at compile-time."         \
+                );                                                                                  \
   ::tts::global_runtime.pass();                                                                     \
-}()                                                                                                 \
+}(std::bool_constant<EXPR>{})                                                                       \
 /**/
 
 #define TTS_CONSTEXPR_EXPECT_NOT(EXPR)                                                              \
-[&]()                                                                                               \
+[]<typename C>(C )                                                                                  \
 {                                                                                                   \
-  static_assert(!(EXPR), "[TTS] - Error: " TTS_STRING(EXPR) " evaluates to true at compile-time."); \
+  static_assert ( !C::value                                                                         \
+                , "[TTS] - Error: " TTS_STRING(EXPR) " evaluates to true at compile-time."          \
+                );                                                                                  \
   ::tts::global_runtime.pass();                                                                     \
-}()                                                                                                 \
+}(std::bool_constant<EXPR>{})                                                                       \
 /**/
+

--- a/src/tts/tools/bitcast.hpp
+++ b/src/tts/tools/bitcast.hpp
@@ -13,10 +13,26 @@
 #include <type_traits>
 #include <utility>
 
+#if !defined(__cpp_lib_bit_cast)
+# include <cstring>
+#endif
+
 namespace tts::detail
 {
-  inline auto as_int(float a)   noexcept  { return std::bit_cast<std::int32_t>(a); }
-  inline auto as_int(double a)  noexcept  { return std::bit_cast<std::int64_t>(a); }
+#if !defined(__cpp_lib_bit_cast)
+  template <class To, class From>
+  To bit_cast(const From& src) noexcept requires(sizeof(To) == sizeof(From))
+  {
+    To dst;
+    std::memcpy(&dst, &src, sizeof(To));
+    return dst;
+  }
+#else
+  using std::bit_cast;
+#endif
+
+  inline auto as_int(float a)   noexcept  { return bit_cast<std::int32_t>(a); }
+  inline auto as_int(double a)  noexcept  { return bit_cast<std::int64_t>(a); }
 
   template<typename T> inline auto bitinteger(T a) noexcept
   {


### PR DESCRIPTION
+ Fix compilation error on MSVC when using complex constexpr expression in constexpr checks
+ Make TTS not rely on std::bit_cast so it can be used on libstdc++-10.3 (Ubuntu LTS 20.04)