### PR TITLE
Add supports for custom output handler

### DIFF
--- a/include/tts/engine/case.hpp
+++ b/include/tts/engine/case.hpp
@@ -54,7 +54,7 @@ namespace tts::_
        {
          // We setup the current type name before each test so we know
          (((current_type = as_text(typename_<Types>)),
-           (::tts::_::current_verbosity.verbose && !::tts::_::current_verbosity.quiet
+           (::tts::is_detailed()
             ? (::tts::output().writeln(">  With <T = %s>", current_type.data()), 0)
             : 0),
            body(type<Types>())),
@@ -98,8 +98,7 @@ namespace tts::_
     template<typename T> static void process_type(auto body)
     {
       current_type = as_text(typename_<T>);
-      if(::tts::_::current_verbosity.verbose && !::tts::_::current_verbosity.quiet)
-        ::tts::output().writeln(">  With <T = %s>", current_type.data());
+      if(::tts::is_detailed()) ::tts::output().writeln(">  With <T = %s>", current_type.data());
       process_call(body, produce(type<T> {}, Generators)...);
     }
 

--- a/include/tts/engine/case.hpp
+++ b/include/tts/engine/case.hpp
@@ -48,19 +48,20 @@ namespace tts::_
       // We register all the types in a single test to keep the compile-time O(1)
       // Registering different type in different tests generate far too much callable::invoker
       // symbol that make compile-time O(N)
-      return test::acknowledge({name,
-                                [ body ]()
-                                {
-                                  // We setup the current type name before each test so we know
-                                  (((current_type = as_text(typename_<Types>)),
-                                    (::tts::_::is_verbose && !::tts::_::is_quiet
-                                     ? printf(">  With <T = %s>\n", current_type.data())
-                                     : 0),
-                                    body(type<Types>())),
-                                   ...);
-                                  // Clear the current type
-                                  current_type = text {""};
-                                }});
+      return test::acknowledge(
+      {name,
+       [ body ]()
+       {
+         // We setup the current type name before each test so we know
+         (((current_type = as_text(typename_<Types>)),
+           (::tts::_::current_verbosity.verbose && !::tts::_::current_verbosity.quiet
+            ? (::tts::output().writeln(">  With <T = %s>", current_type.data()), 0)
+            : 0),
+           body(type<Types>())),
+          ...);
+         // Clear the current type
+         current_type = text {""};
+       }});
     }
     char const* name;
   };
@@ -97,8 +98,8 @@ namespace tts::_
     template<typename T> static void process_type(auto body)
     {
       current_type = as_text(typename_<T>);
-      if(::tts::_::is_verbose && !::tts::_::is_quiet)
-        printf(">  With <T = %s>\n", current_type.data());
+      if(::tts::_::current_verbosity.verbose && !::tts::_::current_verbosity.quiet)
+        ::tts::output().writeln(">  With <T = %s>", current_type.data());
       process_call(body, produce(type<T> {}, Generators)...);
     }
 

--- a/include/tts/engine/environment.hpp
+++ b/include/tts/engine/environment.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <tts/engine/deps.hpp>
+#include <tts/tools/output.hpp>
 
 //======================================================================================================================
 // Test environment
@@ -41,33 +42,35 @@ namespace tts::_
 
     int report(unsigned long long fails, unsigned long long invalids) const
     {
-      auto test_txt = test_count > 1 ? "s" : "";
-      auto pass_txt = success_count > 1 ? "es" : "";
-      auto fail_txt = failure_count > 1 ? "s" : "";
-      auto inv_txt  = invalid_count > 1 ? "s" : "";
+      auto  test_txt = test_count > 1 ? "s" : "";
+      auto  pass_txt = success_count > 1 ? "es" : "";
+      auto  fail_txt = failure_count > 1 ? "s" : "";
+      auto  inv_txt  = invalid_count > 1 ? "s" : "";
 
-      puts("----------------------------------------------------------------");
-      printf("Results: %llu test%s ", test_count, test_txt);
+      auto& out      = ::tts::output();
+
+      out.writeln("----------------------------------------------------------------");
+      out.write("Results: %llu test%s ", test_count, test_txt);
       if(success_count != 0)
-        printf("- %llu/%llu (%2.2f%%) success%s ",
-               success_count,
-               test_count,
-               100.f * static_cast<float>(success_count) / static_cast<float>(test_count),
-               pass_txt);
+        out.write("- %llu/%llu (%2.2f%%) success%s ",
+                  success_count,
+                  test_count,
+                  100.f * static_cast<float>(success_count) / static_cast<float>(test_count),
+                  pass_txt);
       if(failure_count != 0)
-        printf("- %llu/%llu (%2.2f%%) failure%s ",
-               failure_count,
-               test_count,
-               100.f * static_cast<float>(failure_count) / static_cast<float>(test_count),
-               fail_txt);
+        out.write("- %llu/%llu (%2.2f%%) failure%s ",
+                  failure_count,
+                  test_count,
+                  100.f * static_cast<float>(failure_count) / static_cast<float>(test_count),
+                  fail_txt);
       if(invalid_count != 0)
-        printf("- %llu/%llu (%2.2f%%) invalid%s ",
-               invalid_count,
-               test_count,
-               100.f * static_cast<float>(invalid_count) / static_cast<float>(test_count),
-               inv_txt);
+        out.write("- %llu/%llu (%2.2f%%) invalid%s ",
+                  invalid_count,
+                  test_count,
+                  100.f * static_cast<float>(invalid_count) / static_cast<float>(test_count),
+                  inv_txt);
 
-      printf("\n");
+      out.writeln();
 
       if(!fails && !invalids) return test_count == success_count ? 0 : 1;
       else return (failure_count == fails && invalid_count == invalids) ? 0 : 1;

--- a/include/tts/engine/environment.hpp
+++ b/include/tts/engine/environment.hpp
@@ -49,7 +49,7 @@ namespace tts::_
 
       auto& out      = ::tts::output();
 
-      out.writeln("----------------------------------------------------------------");
+      ::tts::_::separator();
       out.write("Results: %llu test%s ", test_count, test_txt);
       if(success_count != 0)
         out.write("- %llu/%llu (%2.2f%%) success%s ",

--- a/include/tts/engine/logger.hpp
+++ b/include/tts/engine/logger.hpp
@@ -30,18 +30,18 @@ namespace tts::_
       {
         if(!done)
         {
-          printf("     >> Additional information: \n     ");
+          ::tts::output().write("     >> Additional information: \n     ");
           done = true;
         }
 
-        printf("%s", as_text(d).data());
+        ::tts::output().write(as_text(d));
       }
       return *this;
     }
 
     ~logger() noexcept(false)
     {
-      if(display && done) puts("");
+      if(display && done) ::tts::output().writeln();
       if(::tts::fatal_error_status) throw ::tts::_::fatal_signal();
     }
 

--- a/include/tts/engine/main.hpp
+++ b/include/tts/engine/main.hpp
@@ -78,33 +78,33 @@ namespace tts::_
 {
   void report_pass(char const* location, char const* message)
   {
-    if(::tts::_::is_verbose && !::tts::_::is_quiet)
+    if(::tts::_::current_verbosity.verbose && !::tts::_::current_verbosity.quiet)
     {
-      printf("  [+] %s : %s\n", location, message);
+      ::tts::output().writeln("  [+] %s : %s", location, message);
     }
   }
 
   void report_fail(char const* location, char const* message, ::tts::text const& type)
   {
-    if(!::tts::_::is_verbose)
+    if(!::tts::_::current_verbosity.verbose)
     {
-      if(!type.is_empty()) printf(">  With <T = %s>\n", type.data());
+      if(!type.is_empty()) ::tts::output().writeln(">  With <T = %s>", type.data());
     }
 
-    if(!::tts::_::is_quiet)
+    if(!::tts::_::current_verbosity.quiet)
     {
-      printf("  [X] %s : ** FAILURE ** : %s\n", location, message);
+      ::tts::output().writeln("  [X] %s : ** FAILURE ** : %s", location, message);
     }
   }
 
   void report_fatal(char const* location, char const* message, ::tts::text const& type)
   {
-    if(!::tts::_::is_verbose)
+    if(!::tts::_::current_verbosity.verbose)
     {
-      if(!type.is_empty()) printf(">  With <T = %s>\n", type.data());
+      if(!type.is_empty()) ::tts::output().writeln(">  With <T = %s>", type.data());
     }
 
-    printf("  [@] %s : @@ FATAL @@ : %s\n", location, message);
+    ::tts::output().writeln("  [@] %s : @@ FATAL @@ : %s", location, message);
   }
 }
 
@@ -113,11 +113,11 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
   ::tts::initialize(argc, argv);
   if(::tts::arguments()("-h", "--help")) return ::tts::_::usage(argv[ 0 ]);
 
-  ::tts::_::is_verbose   = ::tts::arguments()("-v", "--verbose");
-  ::tts::_::is_quiet     = ::tts::arguments()("-q", "--quiet");
+  ::tts::_::current_verbosity.verbose = ::tts::arguments()("-v", "--verbose");
+  ::tts::_::current_verbosity.quiet   = ::tts::arguments()("-q", "--quiet");
 
-  auto        nb_tests   = ::tts::_::suite().size();
-  std::size_t done_tests = 0;
+  auto        nb_tests                = ::tts::_::suite().size();
+  std::size_t done_tests              = 0;
   ::tts::set_random_seed(static_cast<std::uint64_t>(tts::random_seed()));
 
   try
@@ -128,7 +128,7 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
       auto failure_count                = ::tts::global_runtime.failure_count;
       ::tts::global_runtime.fail_status = false;
 
-      if(!::tts::_::is_quiet) printf("TEST: '%s'\n", t.name);
+      if(!::tts::_::current_verbosity.quiet) ::tts::output().writeln("TEST: '%s'", t.name);
       fflush(stdout);
       t();
       done_tests++;
@@ -136,21 +136,22 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
       if(test_count == ::tts::global_runtime.test_count)
       {
         ::tts::global_runtime.invalid();
-        if(!::tts::_::is_quiet) printf("  [!!]: EMPTY TEST CASE\n");
+        if(!::tts::_::current_verbosity.quiet) ::tts::output().writeln("  [!!]: EMPTY TEST CASE");
         fflush(stdout);
       }
       else if(failure_count == ::tts::global_runtime.failure_count)
       {
-        if(!::tts::_::is_quiet) printf("TEST: '%s' - [PASSED]\n", t.name);
+        if(!::tts::_::current_verbosity.quiet)
+          ::tts::output().writeln("TEST: '%s' - [PASSED]", t.name);
         fflush(stdout);
       }
     }
   }
   catch(::tts::_::fatal_signal&)
   {
-    if(!::tts::_::is_quiet)
-      printf("@@ ABORTING DUE TO EARLY FAILURE @@ - %d Tests not run\n",
-             static_cast<int>(nb_tests - done_tests - 1));
+    if(!::tts::_::current_verbosity.quiet)
+      ::tts::output().writeln("@@ ABORTING DUE TO EARLY FAILURE @@ - %d Tests not run",
+                              static_cast<int>(nb_tests - done_tests - 1));
   }
 
   if constexpr(::tts::_::use_main) return ::tts::report(0, 0);

--- a/include/tts/engine/main.hpp
+++ b/include/tts/engine/main.hpp
@@ -117,11 +117,11 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
   ::tts::initialize(argc, argv);
   if(::tts::arguments()("-h", "--help")) return ::tts::_::usage(argv[ 0 ]);
 
-  ::tts::_::current_verbosity.verbose = ::tts::arguments()("-v", "--verbose");
-  ::tts::_::current_verbosity.quiet   = ::tts::arguments()("-q", "--quiet");
+  ::tts::_::set_verbose(::tts::arguments()("-v", "--verbose"));
+  ::tts::_::set_quiet(::tts::arguments()("-q", "--quiet"));
 
-  auto        nb_tests                = ::tts::_::suite().size();
-  std::size_t done_tests              = 0;
+  auto        nb_tests   = ::tts::_::suite().size();
+  std::size_t done_tests = 0;
   ::tts::set_random_seed(static_cast<std::uint64_t>(tts::random_seed()));
 
   try

--- a/include/tts/engine/main.hpp
+++ b/include/tts/engine/main.hpp
@@ -80,10 +80,8 @@ namespace tts::_
   // anywhere else, so it gets reported here instead.
   void report_type_hint(::tts::text const& type)
   {
-    if(!::tts::is_verbose())
-    {
-      if(!type.is_empty()) ::tts::output().writeln(">  With <T = %s>", type.data());
-    }
+    if(!::tts::is_verbose() && !type.is_empty())
+      ::tts::output().writeln(">  With <T = %s>", type.data());
   }
 
   void report_pass(char const* location, char const* message)

--- a/include/tts/engine/main.hpp
+++ b/include/tts/engine/main.hpp
@@ -76,6 +76,16 @@ namespace tts::_
 //======================================================================================================================
 namespace tts::_
 {
+  // Shared by report_fail/report_fatal: outside of verbose mode, the failing type isn't shown
+  // anywhere else, so it gets reported here instead.
+  void report_type_hint(::tts::text const& type)
+  {
+    if(!::tts::is_verbose())
+    {
+      if(!type.is_empty()) ::tts::output().writeln(">  With <T = %s>", type.data());
+    }
+  }
+
   void report_pass(char const* location, char const* message)
   {
     if(::tts::is_detailed())
@@ -86,10 +96,7 @@ namespace tts::_
 
   void report_fail(char const* location, char const* message, ::tts::text const& type)
   {
-    if(!::tts::is_verbose())
-    {
-      if(!type.is_empty()) ::tts::output().writeln(">  With <T = %s>", type.data());
-    }
+    report_type_hint(type);
 
     if(!::tts::is_quiet())
     {
@@ -99,10 +106,7 @@ namespace tts::_
 
   void report_fatal(char const* location, char const* message, ::tts::text const& type)
   {
-    if(!::tts::is_verbose())
-    {
-      if(!type.is_empty()) ::tts::output().writeln(">  With <T = %s>", type.data());
-    }
+    report_type_hint(type);
 
     ::tts::output().writeln("  [@] %s : @@ FATAL @@ : %s", location, message);
   }

--- a/include/tts/engine/main.hpp
+++ b/include/tts/engine/main.hpp
@@ -78,7 +78,7 @@ namespace tts::_
 {
   void report_pass(char const* location, char const* message)
   {
-    if(::tts::_::current_verbosity.verbose && !::tts::_::current_verbosity.quiet)
+    if(::tts::is_detailed())
     {
       ::tts::output().writeln("  [+] %s : %s", location, message);
     }
@@ -86,12 +86,12 @@ namespace tts::_
 
   void report_fail(char const* location, char const* message, ::tts::text const& type)
   {
-    if(!::tts::_::current_verbosity.verbose)
+    if(!::tts::is_verbose())
     {
       if(!type.is_empty()) ::tts::output().writeln(">  With <T = %s>", type.data());
     }
 
-    if(!::tts::_::current_verbosity.quiet)
+    if(!::tts::is_quiet())
     {
       ::tts::output().writeln("  [X] %s : ** FAILURE ** : %s", location, message);
     }
@@ -99,7 +99,7 @@ namespace tts::_
 
   void report_fatal(char const* location, char const* message, ::tts::text const& type)
   {
-    if(!::tts::_::current_verbosity.verbose)
+    if(!::tts::is_verbose())
     {
       if(!type.is_empty()) ::tts::output().writeln(">  With <T = %s>", type.data());
     }
@@ -128,7 +128,7 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
       auto failure_count                = ::tts::global_runtime.failure_count;
       ::tts::global_runtime.fail_status = false;
 
-      if(!::tts::_::current_verbosity.quiet) ::tts::output().writeln("TEST: '%s'", t.name);
+      if(!::tts::is_quiet()) ::tts::output().writeln("TEST: '%s'", t.name);
       fflush(stdout);
       t();
       done_tests++;
@@ -136,20 +136,19 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
       if(test_count == ::tts::global_runtime.test_count)
       {
         ::tts::global_runtime.invalid();
-        if(!::tts::_::current_verbosity.quiet) ::tts::output().writeln("  [!!]: EMPTY TEST CASE");
+        if(!::tts::is_quiet()) ::tts::output().writeln("  [!!]: EMPTY TEST CASE");
         fflush(stdout);
       }
       else if(failure_count == ::tts::global_runtime.failure_count)
       {
-        if(!::tts::_::current_verbosity.quiet)
-          ::tts::output().writeln("TEST: '%s' - [PASSED]", t.name);
+        if(!::tts::is_quiet()) ::tts::output().writeln("TEST: '%s' - [PASSED]", t.name);
         fflush(stdout);
       }
     }
   }
   catch(::tts::_::fatal_signal&)
   {
-    if(!::tts::_::current_verbosity.quiet)
+    if(!::tts::is_quiet())
       ::tts::output().writeln("@@ ABORTING DUE TO EARLY FAILURE @@ - %d Tests not run",
                               static_cast<int>(nb_tests - done_tests - 1));
   }

--- a/include/tts/test/ranges.hpp
+++ b/include/tts/test/ranges.hpp
@@ -22,7 +22,7 @@ namespace tts
     }
     static void display(Base const& v) noexcept
     {
-      printf("%s", as_text(v).data());
+      output().write(as_text(v));
     }
   };
 
@@ -69,28 +69,28 @@ namespace tts
 
     template<typename... S> void header(S const&... s)
     {
-      if(::tts::_::is_quiet) return;
-      ((printf("%-*s", 16, s)), ...);
-      puts("");
+      if(::tts::_::current_verbosity.quiet) return;
+      ((::tts::output().write("%-*s", 16, s)), ...);
+      ::tts::output().writeln();
     }
 
     template<typename U, typename R, typename V>
     void results(U ulp, unsigned int count, R ratio, auto desc, V const& v)
     {
       assert(desc && "Description cannot be null");
-      if(::tts::_::is_quiet) return;
-      if(ulp != -1) printf("%-16.1f%-16u%-16g%s", ulp, count, ratio, desc);
-      else printf("%*s", static_cast<int>(48 + strlen(desc)), desc); // NOSONAR
+      if(::tts::_::current_verbosity.quiet) return;
+      if(ulp != -1) ::tts::output().write("%-16.1f%-16u%-16g%s", ulp, count, ratio, desc);
+      else ::tts::output().write("%*s", static_cast<int>(48 + strlen(desc)), desc); // NOSONAR
       adapter<V>::display(v);
-      printf("\n");
+      ::tts::output().writeln();
     }
 
     template<typename P> void print_producer(P const& prod, auto alt)
     {
-      if(::tts::_::is_quiet) return;
+      if(::tts::_::current_verbosity.quiet) return;
       if constexpr(requires(P const& p) { to_text(p); })
-        printf("%s\n", ::tts::as_text(prod).data());
-      else printf("%s\n", alt);
+        ::tts::output().writeln(::tts::as_text(prod));
+      else ::tts::output().writeln(alt);
     }
   }
 
@@ -148,8 +148,9 @@ namespace tts
     }
 
     _::header("Max ULP", "Count (#)", "Ratio Sum (%)", "Samples");
-    if(!_::is_quiet)
-      printf("--------------------------------------------------------------------------------\n");
+    if(!_::current_verbosity.quiet)
+      ::tts::output().writeln(
+      "--------------------------------------------------------------------------------");
 
     double ratio = 0.;
 
@@ -169,9 +170,9 @@ namespace tts
         _::results(ulps, ulp_map[ i ], ratio, "Input:      ", in);
         _::results(-1., 0, 0., "Found:      ", out);
         _::results(-1., 0, 0., "instead of: ", ref);
-        if(!_::is_quiet)
-          printf(
-          "--------------------------------------------------------------------------------\n");
+        if(!_::current_verbosity.quiet)
+          ::tts::output().writeln(
+          "--------------------------------------------------------------------------------");
       }
     }
 
@@ -205,12 +206,12 @@ namespace tts
 #define TTS_ULP_RANGE_CHECK(Producer, RefType, NewType, RefFunc, NewFunc, Ulpmax)                  \
   [ & ]()                                                                                          \
   {                                                                                                \
-    if(!::tts::_::is_quiet)                                                                        \
-      printf("Comparing: %s<%s> with %s<%s> using ",                                               \
-             TTS_STRING(RefFunc),                                                                  \
-             TTS_STRING(TTS_REMOVE_PARENS(RefType)),                                               \
-             TTS_STRING(NewFunc),                                                                  \
-             TTS_STRING(TTS_REMOVE_PARENS(NewType)));                                              \
+    if(!::tts::_::current_verbosity.quiet)                                                         \
+      ::tts::output().write("Comparing: %s<%s> with %s<%s> using ",                                \
+                            TTS_STRING(RefFunc),                                                   \
+                            TTS_STRING(TTS_REMOVE_PARENS(RefType)),                                \
+                            TTS_STRING(NewFunc),                                                   \
+                            TTS_STRING(TTS_REMOVE_PARENS(NewType)));                               \
                                                                                                    \
     auto generator = TTS_REMOVE_PARENS(Producer);                                                  \
     ::tts::_::print_producer(generator, TTS_STRING(TTS_REMOVE_PARENS(Producer)));                  \

--- a/include/tts/test/ranges.hpp
+++ b/include/tts/test/ranges.hpp
@@ -69,7 +69,7 @@ namespace tts
 
     template<typename... S> void header(S const&... s)
     {
-      if(::tts::_::current_verbosity.quiet) return;
+      if(::tts::is_quiet()) return;
       ((::tts::output().write("%-*s", 16, s)), ...);
       ::tts::output().writeln();
     }
@@ -78,7 +78,7 @@ namespace tts
     void results(U ulp, unsigned int count, R ratio, auto desc, V const& v)
     {
       assert(desc && "Description cannot be null");
-      if(::tts::_::current_verbosity.quiet) return;
+      if(::tts::is_quiet()) return;
       if(ulp != -1) ::tts::output().write("%-16.1f%-16u%-16g%s", ulp, count, ratio, desc);
       else ::tts::output().write("%*s", static_cast<int>(48 + strlen(desc)), desc); // NOSONAR
       adapter<V>::display(v);
@@ -87,7 +87,7 @@ namespace tts
 
     template<typename P> void print_producer(P const& prod, auto alt)
     {
-      if(::tts::_::current_verbosity.quiet) return;
+      if(::tts::is_quiet()) return;
       if constexpr(requires(P const& p) { to_text(p); })
         ::tts::output().writeln(::tts::as_text(prod));
       else ::tts::output().writeln(alt);
@@ -148,7 +148,7 @@ namespace tts
     }
 
     _::header("Max ULP", "Count (#)", "Ratio Sum (%)", "Samples");
-    if(!_::current_verbosity.quiet)
+    if(!::tts::is_quiet())
       ::tts::output().writeln(
       "--------------------------------------------------------------------------------");
 
@@ -170,7 +170,7 @@ namespace tts
         _::results(ulps, ulp_map[ i ], ratio, "Input:      ", in);
         _::results(-1., 0, 0., "Found:      ", out);
         _::results(-1., 0, 0., "instead of: ", ref);
-        if(!_::current_verbosity.quiet)
+        if(!::tts::is_quiet())
           ::tts::output().writeln(
           "--------------------------------------------------------------------------------");
       }
@@ -206,7 +206,7 @@ namespace tts
 #define TTS_ULP_RANGE_CHECK(Producer, RefType, NewType, RefFunc, NewFunc, Ulpmax)                  \
   [ & ]()                                                                                          \
   {                                                                                                \
-    if(!::tts::_::current_verbosity.quiet)                                                         \
+    if(!::tts::is_quiet())                                                                         \
       ::tts::output().write("Comparing: %s<%s> with %s<%s> using ",                                \
                             TTS_STRING(RefFunc),                                                   \
                             TTS_STRING(TTS_REMOVE_PARENS(RefType)),                                \

--- a/include/tts/test/ranges.hpp
+++ b/include/tts/test/ranges.hpp
@@ -148,9 +148,7 @@ namespace tts
     }
 
     _::header("Max ULP", "Count (#)", "Ratio Sum (%)", "Samples");
-    if(!::tts::is_quiet())
-      ::tts::output().writeln(
-      "--------------------------------------------------------------------------------");
+    _::separator(!::tts::is_quiet());
 
     double ratio = 0.;
 
@@ -170,9 +168,7 @@ namespace tts
         _::results(ulps, ulp_map[ i ], ratio, "Input:      ", in);
         _::results(-1., 0, 0., "Found:      ", out);
         _::results(-1., 0, 0., "instead of: ", ref);
-        if(!::tts::is_quiet())
-          ::tts::output().writeln(
-          "--------------------------------------------------------------------------------");
+        _::separator(!::tts::is_quiet());
       }
     }
 

--- a/include/tts/test/when.hpp
+++ b/include/tts/test/when.hpp
@@ -28,7 +28,8 @@ namespace tts::_
 
     bool check(char const* desc)
     {
-      if(id == section && desc && is_verbose) printf("  And then: %s\n", desc);
+      if(id == section && desc && current_verbosity.verbose)
+        ::tts::output().writeln("  And then: %s", desc);
       return id == section;
     }
   };
@@ -75,7 +76,9 @@ namespace tts::_
 #define TTS_WHEN(STORY)                                                                            \
   TTS_DISABLE_WARNING_PUSH                                                                         \
   TTS_DISABLE_WARNING_SHADOW(                                                                      \
-  ::tts::_::is_verbose ? printf("When      : %s\n", ::tts::text {STORY}.data()) : 0);              \
+  ::tts::_::current_verbosity.verbose                                                              \
+  ? (::tts::output().writeln("When      : %s", ::tts::text {STORY}.data()), 0)                     \
+  : 0);                                                                                            \
   for(int tts_section = 0, tts_count = 1; tts_section < tts_count;                                 \
       tts_count -= 0 == tts_section++)                                                             \
     for(tts::_::only_once tts_only_once_setup {}; tts_only_once_setup;)                            \

--- a/include/tts/test/when.hpp
+++ b/include/tts/test/when.hpp
@@ -28,7 +28,7 @@ namespace tts::_
 
     bool check(char const* desc)
     {
-      if(id == section && desc && current_verbosity.verbose)
+      if(id == section && desc && ::tts::is_verbose())
         ::tts::output().writeln("  And then: %s", desc);
       return id == section;
     }
@@ -76,9 +76,8 @@ namespace tts::_
 #define TTS_WHEN(STORY)                                                                            \
   TTS_DISABLE_WARNING_PUSH                                                                         \
   TTS_DISABLE_WARNING_SHADOW(                                                                      \
-  ::tts::_::current_verbosity.verbose                                                              \
-  ? (::tts::output().writeln("When      : %s", ::tts::text {STORY}.data()), 0)                     \
-  : 0);                                                                                            \
+  ::tts::is_verbose() ? (::tts::output().writeln("When      : %s", ::tts::text {STORY}.data()), 0) \
+                      : 0);                                                                        \
   for(int tts_section = 0, tts_count = 1; tts_section < tts_count;                                 \
       tts_count -= 0 == tts_section++)                                                             \
     for(tts::_::only_once tts_only_once_setup {}; tts_only_once_setup;)                            \

--- a/include/tts/tools/options.hpp
+++ b/include/tts/tools/options.hpp
@@ -269,6 +269,37 @@ namespace tts
   {
     return _::current_verbosity.verbose;
   }
+
+  //====================================================================================================================
+  /**
+    @ingroup tools-config
+    @public
+    @brief Check if quiet mode is enabled
+
+    @return `true` if quiet mode is enabled, `false` otherwise.
+            Quiet mode is enabled when the `--quiet` or `-q` command line argument is provided.
+  **/
+  //====================================================================================================================
+  inline bool is_quiet()
+  {
+    return _::current_verbosity.quiet;
+  }
+
+  //====================================================================================================================
+  /**
+    @ingroup tools-config
+    @public
+    @brief Check if verbose-only details should be reported
+
+    @return `true` if verbose mode is enabled and quiet mode is not, `false` otherwise. This is the
+            condition under which extra detail lines - like passing test confirmations or type
+            hints - get reported: quiet mode always takes precedence over verbose mode.
+  **/
+  //====================================================================================================================
+  inline bool is_detailed()
+  {
+    return is_verbose() && !is_quiet();
+  }
 }
 
 TTS_DISABLE_WARNING_POP

--- a/include/tts/tools/options.hpp
+++ b/include/tts/tools/options.hpp
@@ -7,6 +7,7 @@
 */
 //======================================================================================================================
 #pragma once
+#include <tts/tools/output.hpp>
 #include <tts/tools/preprocessor.hpp>
 
 TTS_DISABLE_WARNING_PUSH
@@ -186,8 +187,6 @@ namespace tts
   {
     inline options current_arguments = {0, nullptr};
     inline int     current_seed      = -1;
-    inline bool    is_verbose        = false;
-    inline bool    is_quiet          = false;
   }
 
   //====================================================================================================================
@@ -268,7 +267,7 @@ namespace tts
   //====================================================================================================================
   inline bool is_verbose()
   {
-    return _::is_verbose;
+    return _::current_verbosity.verbose;
   }
 }
 

--- a/include/tts/tools/output.hpp
+++ b/include/tts/tools/output.hpp
@@ -1,0 +1,237 @@
+//======================================================================================================================
+//! @file
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//======================================================================================================================
+#pragma once
+
+#include <tts/tools/text.hpp>
+
+namespace tts::_
+{
+  //====================================================================================================================
+  // Current test suite verbosity settings, set from the -v/--verbose and -q/--quiet CLI flags.
+  // This is the single source of truth for what should be reported and is kept independent from
+  // how a message actually gets emitted, which is the job of tts::output_handler below.
+  //====================================================================================================================
+  struct verbosity
+  {
+    bool verbose = false;
+    bool quiet   = false;
+  };
+
+  inline verbosity current_verbosity = {};
+}
+
+namespace tts
+{
+  //====================================================================================================================
+  /**
+    @defgroup tools-output Output Utilities
+    @{
+  **/
+  //====================================================================================================================
+
+  //====================================================================================================================
+  /**
+    @public
+    @brief Customization point for where TTS output actually goes.
+
+    All non-usage related output produced while running a test suite - tests progress, pass/fail/
+    fatal reports, additional logging information and the final results report - is written
+    through the tts::output_handler currently in use, which itself forwards every message to an
+    output_sink. Deriving from output_sink and overriding write() lets power users redirect that
+    output wherever they need to: a file, a GUI widget, a socket, another logging system...
+
+    @groupheader{Example}
+    @snippet doc/custom_output_sink.cpp snippet
+
+    @see tts::output_handler
+    @see tts::stdout_sink
+    @see tts::gathering_sink
+  **/
+  //====================================================================================================================
+  struct output_sink
+  {
+    /// Writes t to this sink's destination.
+    virtual void write(text const& t) = 0;
+    virtual ~output_sink()            = default;
+  };
+
+  //====================================================================================================================
+  /**
+    @public
+    @brief Default output_sink, streaming every message straight to `stdout`.
+
+    This is the sink TTS uses unless a power user installs another one, matching its historical
+    behavior of streaming output as it is produced.
+  **/
+  //====================================================================================================================
+  struct stdout_sink : output_sink
+  {
+    void write(text const& t) override
+    {
+      fputs(t.data(), stdout);
+    }
+  };
+
+  //====================================================================================================================
+  /**
+    @public
+    @brief output_sink gathering every message into a single retrievable buffer.
+
+    Instead of streaming messages as they are written, gathering_sink accumulates them into a
+    single tts::text. That buffer can be inspected at any time via content(), streamed out at once
+    via dump(), or discarded via clear().
+
+    @groupheader{Example}
+    @code
+    tts::gathering_sink report;
+    tts::output().sink(report);
+
+    // ... run the test suite ...
+
+    report.dump();                        // stream everything gathered so far at once
+    // or
+    do_something_with(report.content());  // retrieve it to do something else entirely
+    @endcode
+  **/
+  //====================================================================================================================
+  struct gathering_sink : output_sink
+  {
+    void write(text const& t) override
+    {
+      buffer_ += t;
+    }
+
+    /// Retrieves everything gathered so far.
+    text const& content() const
+    {
+      return buffer_;
+    }
+
+    /// Streams everything gathered so far to `stdout`, then clears the buffer.
+    void dump()
+    {
+      fputs(buffer_.data(), stdout);
+      clear();
+    }
+
+    /// Discards everything gathered so far.
+    void clear()
+    {
+      buffer_ = text {};
+    }
+
+  private:
+    text buffer_;
+  };
+
+  //====================================================================================================================
+  /**
+    @public
+    @brief Centralizes all TTS runtime output and dispatches it to the current output_sink.
+
+    tts::output_handler is the class every piece of non-usage related TTS output goes through. It
+    exposes formatted writing at the granularity actually needed by the engine - a fragment, a
+    full line, raw text or a printf-style message - and forwards the result to whichever
+    output_sink is currently installed (tts::stdout_sink by default).
+
+    @see tts::output
+    @see tts::output_sink
+  **/
+  //====================================================================================================================
+  class output_handler
+  {
+  public:
+    /// Constructs an output_handler using s as its initial output_sink.
+    explicit output_handler(output_sink& s = default_sink())
+        : sink_(&s)
+    {
+    }
+
+    /// Writes a pre-built tts::text as-is.
+    void write(text const& t)
+    {
+      sink_->write(t);
+    }
+
+    /// Writes a raw C-string as-is.
+    void write(char const* s)
+    {
+      sink_->write(text(s));
+    }
+
+    /// Writes a printf-style formatted message.
+    template<typename... Args> void write(char const* format, Args const&... args)
+    {
+      sink_->write(text(format, args...));
+    }
+
+    /// Writes a pre-built tts::text followed by a newline.
+    void writeln(text const& t = text {})
+    {
+      sink_->write(t);
+      sink_->write(text("\n"));
+    }
+
+    /// Writes a raw C-string followed by a newline.
+    void writeln(char const* s)
+    {
+      writeln(text(s));
+    }
+
+    /// Writes a printf-style formatted message followed by a newline.
+    template<typename... Args> void writeln(char const* format, Args const&... args)
+    {
+      writeln(text(format, args...));
+    }
+
+    /// Installs s as the output_sink every subsequent write goes to.
+    void sink(output_sink& s)
+    {
+      sink_ = &s;
+    }
+
+    /// Retrieves the output_sink currently in use.
+    output_sink& sink() const
+    {
+      return *sink_;
+    }
+
+    /// The output_sink TTS uses unless a power user installs another one.
+    static stdout_sink& default_sink()
+    {
+      static stdout_sink that = {};
+      return that;
+    }
+
+  private:
+    output_sink* sink_;
+  };
+
+  namespace _
+  {
+    inline output_handler current_output {};
+  }
+
+  //====================================================================================================================
+  /**
+    @public
+    @brief Retrieves the current TTS output_handler.
+
+    @return A reference to the tts::output_handler instance used by the current test suite.
+  **/
+  //====================================================================================================================
+  inline output_handler& output()
+  {
+    return _::current_output;
+  }
+
+  //====================================================================================================================
+  //! @}
+  //====================================================================================================================
+}

--- a/include/tts/tools/output.hpp
+++ b/include/tts/tools/output.hpp
@@ -46,10 +46,7 @@ namespace tts::_
   //====================================================================================================================
   struct verbosity_scope
   {
-    verbosity_scope()
-        : saved(current_verbosity)
-    {
-    }
+    verbosity_scope() = default;
 
     ~verbosity_scope()
     {
@@ -61,7 +58,7 @@ namespace tts::_
     verbosity_scope(verbosity_scope&&)                 = delete;
     verbosity_scope& operator=(verbosity_scope&&)      = delete;
 
-    verbosity        saved;
+    verbosity        saved                             = current_verbosity;
   };
 }
 

--- a/include/tts/tools/output.hpp
+++ b/include/tts/tools/output.hpp
@@ -23,7 +23,7 @@ namespace tts::_
     bool quiet   = false;
   };
 
-  inline verbosity current_verbosity = {};
+  inline verbosity current_verbosity = {}; // NOSONAR
 
   //====================================================================================================================
   // Sole writers for current_verbosity: every read goes through is_verbose()/is_quiet()/

--- a/include/tts/tools/output.hpp
+++ b/include/tts/tools/output.hpp
@@ -26,6 +26,20 @@ namespace tts::_
   inline verbosity current_verbosity = {};
 
   //====================================================================================================================
+  // Sole writers for current_verbosity: every read goes through is_verbose()/is_quiet()/
+  // is_detailed(), so every write is funneled through these instead of poking the fields directly.
+  //====================================================================================================================
+  inline void set_verbose(bool verbose)
+  {
+    current_verbosity.verbose = verbose;
+  }
+
+  inline void set_quiet(bool quiet)
+  {
+    current_verbosity.quiet = quiet;
+  }
+
+  //====================================================================================================================
   // RAII guard saving current_verbosity on construction and restoring it on destruction. Meant for
   // tests that need to exercise a specific verbose/quiet combination without leaking that state
   // into the rest of the running test suite, even if the test exits early.

--- a/include/tts/tools/output.hpp
+++ b/include/tts/tools/output.hpp
@@ -56,7 +56,12 @@ namespace tts::_
       current_verbosity = saved;
     }
 
-    verbosity saved;
+    verbosity_scope(verbosity_scope const&)            = delete;
+    verbosity_scope& operator=(verbosity_scope const&) = delete;
+    verbosity_scope(verbosity_scope&&)                 = delete;
+    verbosity_scope& operator=(verbosity_scope&&)      = delete;
+
+    verbosity        saved;
   };
 }
 

--- a/include/tts/tools/output.hpp
+++ b/include/tts/tools/output.hpp
@@ -24,6 +24,26 @@ namespace tts::_
   };
 
   inline verbosity current_verbosity = {};
+
+  //====================================================================================================================
+  // RAII guard saving current_verbosity on construction and restoring it on destruction. Meant for
+  // tests that need to exercise a specific verbose/quiet combination without leaking that state
+  // into the rest of the running test suite, even if the test exits early.
+  //====================================================================================================================
+  struct verbosity_scope
+  {
+    verbosity_scope()
+        : saved(current_verbosity)
+    {
+    }
+
+    ~verbosity_scope()
+    {
+      current_verbosity = saved;
+    }
+
+    verbosity saved;
+  };
 }
 
 namespace tts
@@ -234,4 +254,19 @@ namespace tts
   //====================================================================================================================
   //! @}
   //====================================================================================================================
+}
+
+namespace tts::_
+{
+  //====================================================================================================================
+  // Shared separator line for display helpers to visually delimit sections of output (see
+  // tts::_::header/results in ranges.hpp). printable lets a caller fold its own display condition
+  // (e.g. !tts::is_quiet()) into the call instead of guarding it at every call site.
+  //====================================================================================================================
+  inline void separator(bool printable = true)
+  {
+    if(printable)
+      ::tts::output().writeln(
+      "--------------------------------------------------------------------------------");
+  }
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ copa_make_single_unit ( INTERFACE     tts_test
                                       unit/infrastructure/buffer.cpp
                                       unit/infrastructure/callable.cpp
                                       unit/infrastructure/display.cpp
+                                      unit/infrastructure/output.cpp
                                       unit/infrastructure/main.cpp
                         ROOT          ${root}
                         NAME          unit.infrastructure.basic.cpp

--- a/test/unit/doc/custom_output_sink.cpp
+++ b/test/unit/doc/custom_output_sink.cpp
@@ -1,0 +1,47 @@
+//==================================================================================================
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+
+//! [snippet]
+#define TTS_MAIN
+#define TTS_CUSTOM_DRIVER_FUNCTION custom_sink_main
+#include <tts/tts.hpp>
+
+// A power-user output_sink prefixing every message TTS writes before forwarding it to stdout.
+struct prefixed_sink : tts::output_sink
+{
+  int  messages = 0;
+
+  void write(tts::text const& t) override
+  {
+    messages++;
+    if(t != "\n") fputs("[MY-TTS] ", stdout);
+    fputs(t.data(), stdout);
+  }
+};
+
+TTS_CASE("Some test running through our custom output_sink")
+{
+  TTS_EXPECT(1 == 1);
+};
+
+int main(int argc, char const** argv)
+{
+  ::tts::initialize(argc, argv);
+
+  prefixed_sink sink;
+  tts::output().sink(sink); // Install our custom sink...
+
+  custom_sink_main(argc, argv); // ...run the test suite through it...
+
+  tts::output().sink(tts::output_handler::default_sink()); // ...then restore the default one.
+
+  printf("Our custom output_sink received %d message(s)\n", sink.messages);
+
+  return tts::report(0, 0);
+}
+//! [snippet]

--- a/test/unit/infrastructure/output.cpp
+++ b/test/unit/infrastructure/output.cpp
@@ -119,3 +119,54 @@ TTS_CASE("Check output_handler dispatches to a power user defined output_sink")
   TTS_EQUAL(custom.calls, 1);
   TTS_EQUAL(custom.last, "custom output");
 };
+
+TTS_CASE("Check report_fail only shows the failing type outside verbose mode")
+{
+  bool const          previous_verbose = ::tts::_::current_verbosity.verbose;
+  bool const          previous_quiet   = ::tts::_::current_verbosity.quiet;
+
+  tts::gathering_sink gs;
+  auto&               out      = tts::output();
+  auto&               previous = out.sink();
+  out.sink(gs);
+
+  // Quiet hides the "[X] ... FAILURE ..." line so only the type hint remains, isolating it.
+  ::tts::_::current_verbosity.verbose = false;
+  ::tts::_::current_verbosity.quiet   = true;
+  ::tts::_::report_fail("[loc]", "msg", ::tts::text {"int"});
+  TTS_EQUAL(gs.content(), ">  With <T = int>\n");
+
+  gs.clear();
+  ::tts::_::current_verbosity.verbose = true;
+  ::tts::_::report_fail("[loc]", "msg", ::tts::text {"int"});
+  TTS_EXPECT(gs.content().is_empty());
+
+  out.sink(previous);
+  ::tts::_::current_verbosity.verbose = previous_verbose;
+  ::tts::_::current_verbosity.quiet   = previous_quiet;
+};
+
+TTS_CASE("Check report_fatal shares the same type hint behavior as report_fail")
+{
+  bool const          previous_verbose = ::tts::_::current_verbosity.verbose;
+  bool const          previous_quiet   = ::tts::_::current_verbosity.quiet;
+
+  tts::gathering_sink gs;
+  auto&               out      = tts::output();
+  auto&               previous = out.sink();
+  out.sink(gs);
+
+  ::tts::_::current_verbosity.verbose = false;
+  ::tts::_::current_verbosity.quiet   = false;
+  ::tts::_::report_fatal("[loc]", "msg", ::tts::text {"int"});
+  TTS_EQUAL(gs.content(), ">  With <T = int>\n  [@] [loc] : @@ FATAL @@ : msg\n");
+
+  gs.clear();
+  ::tts::_::current_verbosity.verbose = true;
+  ::tts::_::report_fatal("[loc]", "msg", ::tts::text {"int"});
+  TTS_EQUAL(gs.content(), "  [@] [loc] : @@ FATAL @@ : msg\n");
+
+  out.sink(previous);
+  ::tts::_::current_verbosity.verbose = previous_verbose;
+  ::tts::_::current_verbosity.quiet   = previous_quiet;
+};

--- a/test/unit/infrastructure/output.cpp
+++ b/test/unit/infrastructure/output.cpp
@@ -7,17 +7,39 @@
 //==================================================================================================
 #include <tts/tts.hpp>
 
+TTS_CASE("Check set_verbose and set_quiet are the only writers of current_verbosity")
+{
+  ::tts::_::verbosity_scope scope;
+
+  ::tts::_::set_verbose(false);
+  ::tts::_::set_quiet(false);
+  TTS_EXPECT_NOT(::tts::_::current_verbosity.verbose);
+  TTS_EXPECT_NOT(::tts::_::current_verbosity.quiet);
+
+  ::tts::_::set_verbose(true);
+  TTS_EXPECT(::tts::_::current_verbosity.verbose);
+  TTS_EXPECT_NOT(::tts::_::current_verbosity.quiet);
+
+  ::tts::_::set_quiet(true);
+  TTS_EXPECT(::tts::_::current_verbosity.verbose);
+  TTS_EXPECT(::tts::_::current_verbosity.quiet);
+
+  ::tts::_::set_verbose(false);
+  TTS_EXPECT_NOT(::tts::_::current_verbosity.verbose);
+  TTS_EXPECT(::tts::_::current_verbosity.quiet);
+};
+
 TTS_CASE("Check verbosity_scope saves and restores current_verbosity")
 {
   ::tts::_::verbosity_scope outer; // restores whatever was in place before this test ran
 
-  ::tts::_::current_verbosity.verbose = false;
-  ::tts::_::current_verbosity.quiet   = true;
+  ::tts::_::set_verbose(false);
+  ::tts::_::set_quiet(true);
 
   {
     ::tts::_::verbosity_scope inner;
-    ::tts::_::current_verbosity.verbose = true;
-    ::tts::_::current_verbosity.quiet   = false;
+    ::tts::_::set_verbose(true);
+    ::tts::_::set_quiet(false);
     TTS_EXPECT(tts::is_verbose());
     TTS_EXPECT_NOT(tts::is_quiet());
   }
@@ -30,16 +52,16 @@ TTS_CASE("Check is_verbose and is_quiet reflect the current verbosity state")
 {
   ::tts::_::verbosity_scope scope;
 
-  ::tts::_::current_verbosity.verbose = false;
-  ::tts::_::current_verbosity.quiet   = false;
+  ::tts::_::set_verbose(false);
+  ::tts::_::set_quiet(false);
   TTS_EXPECT_NOT(tts::is_verbose());
   TTS_EXPECT_NOT(tts::is_quiet());
 
-  ::tts::_::current_verbosity.verbose = true;
+  ::tts::_::set_verbose(true);
   TTS_EXPECT(tts::is_verbose());
   TTS_EXPECT_NOT(tts::is_quiet());
 
-  ::tts::_::current_verbosity.quiet = true;
+  ::tts::_::set_quiet(true);
   TTS_EXPECT(tts::is_verbose());
   TTS_EXPECT(tts::is_quiet());
 };
@@ -48,20 +70,20 @@ TTS_CASE("Check is_detailed is true only when verbose is set and quiet is not")
 {
   ::tts::_::verbosity_scope scope;
 
-  ::tts::_::current_verbosity.verbose = false;
-  ::tts::_::current_verbosity.quiet   = false;
+  ::tts::_::set_verbose(false);
+  ::tts::_::set_quiet(false);
   TTS_EXPECT_NOT(tts::is_detailed());
 
-  ::tts::_::current_verbosity.verbose = true;
-  ::tts::_::current_verbosity.quiet   = false;
+  ::tts::_::set_verbose(true);
+  ::tts::_::set_quiet(false);
   TTS_EXPECT(tts::is_detailed());
 
-  ::tts::_::current_verbosity.verbose = true;
-  ::tts::_::current_verbosity.quiet   = true;
+  ::tts::_::set_verbose(true);
+  ::tts::_::set_quiet(true);
   TTS_EXPECT_NOT(tts::is_detailed());
 
-  ::tts::_::current_verbosity.verbose = false;
-  ::tts::_::current_verbosity.quiet   = true;
+  ::tts::_::set_verbose(false);
+  ::tts::_::set_quiet(true);
   TTS_EXPECT_NOT(tts::is_detailed());
 };
 
@@ -163,13 +185,13 @@ TTS_CASE("Check report_fail only shows the failing type outside verbose mode")
   out.sink(gs);
 
   // Quiet hides the "[X] ... FAILURE ..." line so only the type hint remains, isolating it.
-  ::tts::_::current_verbosity.verbose = false;
-  ::tts::_::current_verbosity.quiet   = true;
+  ::tts::_::set_verbose(false);
+  ::tts::_::set_quiet(true);
   ::tts::_::report_fail("[loc]", "msg", ::tts::text {"int"});
   TTS_EQUAL(gs.content(), ">  With <T = int>\n");
 
   gs.clear();
-  ::tts::_::current_verbosity.verbose = true;
+  ::tts::_::set_verbose(true);
   ::tts::_::report_fail("[loc]", "msg", ::tts::text {"int"});
   TTS_EXPECT(gs.content().is_empty());
 
@@ -185,13 +207,13 @@ TTS_CASE("Check report_fatal shares the same type hint behavior as report_fail")
   auto&                     previous = out.sink();
   out.sink(gs);
 
-  ::tts::_::current_verbosity.verbose = false;
-  ::tts::_::current_verbosity.quiet   = false;
+  ::tts::_::set_verbose(false);
+  ::tts::_::set_quiet(false);
   ::tts::_::report_fatal("[loc]", "msg", ::tts::text {"int"});
   TTS_EQUAL(gs.content(), ">  With <T = int>\n  [@] [loc] : @@ FATAL @@ : msg\n");
 
   gs.clear();
-  ::tts::_::current_verbosity.verbose = true;
+  ::tts::_::set_verbose(true);
   ::tts::_::report_fatal("[loc]", "msg", ::tts::text {"int"});
   TTS_EQUAL(gs.content(), "  [@] [loc] : @@ FATAL @@ : msg\n");
 

--- a/test/unit/infrastructure/output.cpp
+++ b/test/unit/infrastructure/output.cpp
@@ -7,6 +7,53 @@
 //==================================================================================================
 #include <tts/tts.hpp>
 
+TTS_CASE("Check is_verbose and is_quiet reflect the current verbosity state")
+{
+  bool const previous_verbose         = ::tts::_::current_verbosity.verbose;
+  bool const previous_quiet           = ::tts::_::current_verbosity.quiet;
+
+  ::tts::_::current_verbosity.verbose = false;
+  ::tts::_::current_verbosity.quiet   = false;
+  TTS_EXPECT_NOT(tts::is_verbose());
+  TTS_EXPECT_NOT(tts::is_quiet());
+
+  ::tts::_::current_verbosity.verbose = true;
+  TTS_EXPECT(tts::is_verbose());
+  TTS_EXPECT_NOT(tts::is_quiet());
+
+  ::tts::_::current_verbosity.quiet = true;
+  TTS_EXPECT(tts::is_verbose());
+  TTS_EXPECT(tts::is_quiet());
+
+  ::tts::_::current_verbosity.verbose = previous_verbose;
+  ::tts::_::current_verbosity.quiet   = previous_quiet;
+};
+
+TTS_CASE("Check is_detailed is true only when verbose is set and quiet is not")
+{
+  bool const previous_verbose         = ::tts::_::current_verbosity.verbose;
+  bool const previous_quiet           = ::tts::_::current_verbosity.quiet;
+
+  ::tts::_::current_verbosity.verbose = false;
+  ::tts::_::current_verbosity.quiet   = false;
+  TTS_EXPECT_NOT(tts::is_detailed());
+
+  ::tts::_::current_verbosity.verbose = true;
+  ::tts::_::current_verbosity.quiet   = false;
+  TTS_EXPECT(tts::is_detailed());
+
+  ::tts::_::current_verbosity.verbose = true;
+  ::tts::_::current_verbosity.quiet   = true;
+  TTS_EXPECT_NOT(tts::is_detailed());
+
+  ::tts::_::current_verbosity.verbose = false;
+  ::tts::_::current_verbosity.quiet   = true;
+  TTS_EXPECT_NOT(tts::is_detailed());
+
+  ::tts::_::current_verbosity.verbose = previous_verbose;
+  ::tts::_::current_verbosity.quiet   = previous_quiet;
+};
+
 TTS_CASE("Check output_handler defaults to tts::output_handler::default_sink")
 {
   TTS_EXPECT(&tts::output().sink() == &tts::output_handler::default_sink());

--- a/test/unit/infrastructure/output.cpp
+++ b/test/unit/infrastructure/output.cpp
@@ -7,10 +7,28 @@
 //==================================================================================================
 #include <tts/tts.hpp>
 
+TTS_CASE("Check verbosity_scope saves and restores current_verbosity")
+{
+  ::tts::_::verbosity_scope outer; // restores whatever was in place before this test ran
+
+  ::tts::_::current_verbosity.verbose = false;
+  ::tts::_::current_verbosity.quiet   = true;
+
+  {
+    ::tts::_::verbosity_scope inner;
+    ::tts::_::current_verbosity.verbose = true;
+    ::tts::_::current_verbosity.quiet   = false;
+    TTS_EXPECT(tts::is_verbose());
+    TTS_EXPECT_NOT(tts::is_quiet());
+  }
+
+  TTS_EXPECT_NOT(tts::is_verbose());
+  TTS_EXPECT(tts::is_quiet());
+};
+
 TTS_CASE("Check is_verbose and is_quiet reflect the current verbosity state")
 {
-  bool const previous_verbose         = ::tts::_::current_verbosity.verbose;
-  bool const previous_quiet           = ::tts::_::current_verbosity.quiet;
+  ::tts::_::verbosity_scope scope;
 
   ::tts::_::current_verbosity.verbose = false;
   ::tts::_::current_verbosity.quiet   = false;
@@ -24,15 +42,11 @@ TTS_CASE("Check is_verbose and is_quiet reflect the current verbosity state")
   ::tts::_::current_verbosity.quiet = true;
   TTS_EXPECT(tts::is_verbose());
   TTS_EXPECT(tts::is_quiet());
-
-  ::tts::_::current_verbosity.verbose = previous_verbose;
-  ::tts::_::current_verbosity.quiet   = previous_quiet;
 };
 
 TTS_CASE("Check is_detailed is true only when verbose is set and quiet is not")
 {
-  bool const previous_verbose         = ::tts::_::current_verbosity.verbose;
-  bool const previous_quiet           = ::tts::_::current_verbosity.quiet;
+  ::tts::_::verbosity_scope scope;
 
   ::tts::_::current_verbosity.verbose = false;
   ::tts::_::current_verbosity.quiet   = false;
@@ -49,9 +63,28 @@ TTS_CASE("Check is_detailed is true only when verbose is set and quiet is not")
   ::tts::_::current_verbosity.verbose = false;
   ::tts::_::current_verbosity.quiet   = true;
   TTS_EXPECT_NOT(tts::is_detailed());
+};
 
-  ::tts::_::current_verbosity.verbose = previous_verbose;
-  ::tts::_::current_verbosity.quiet   = previous_quiet;
+TTS_CASE("Check separator writes an 80-dash line only when printable is true")
+{
+  tts::gathering_sink gs;
+  auto&               out      = tts::output();
+  auto&               previous = out.sink();
+  out.sink(gs);
+
+  ::tts::_::separator(false);
+  TTS_EXPECT(gs.content().is_empty());
+
+  ::tts::_::separator(true);
+  TTS_EQUAL(gs.content(),
+            "--------------------------------------------------------------------------------\n");
+
+  gs.clear();
+  ::tts::_::separator();
+  TTS_EQUAL(gs.content(),
+            "--------------------------------------------------------------------------------\n");
+
+  out.sink(previous);
 };
 
 TTS_CASE("Check output_handler defaults to tts::output_handler::default_sink")
@@ -122,12 +155,11 @@ TTS_CASE("Check output_handler dispatches to a power user defined output_sink")
 
 TTS_CASE("Check report_fail only shows the failing type outside verbose mode")
 {
-  bool const          previous_verbose = ::tts::_::current_verbosity.verbose;
-  bool const          previous_quiet   = ::tts::_::current_verbosity.quiet;
+  ::tts::_::verbosity_scope scope;
 
-  tts::gathering_sink gs;
-  auto&               out      = tts::output();
-  auto&               previous = out.sink();
+  tts::gathering_sink       gs;
+  auto&                     out      = tts::output();
+  auto&                     previous = out.sink();
   out.sink(gs);
 
   // Quiet hides the "[X] ... FAILURE ..." line so only the type hint remains, isolating it.
@@ -142,18 +174,15 @@ TTS_CASE("Check report_fail only shows the failing type outside verbose mode")
   TTS_EXPECT(gs.content().is_empty());
 
   out.sink(previous);
-  ::tts::_::current_verbosity.verbose = previous_verbose;
-  ::tts::_::current_verbosity.quiet   = previous_quiet;
 };
 
 TTS_CASE("Check report_fatal shares the same type hint behavior as report_fail")
 {
-  bool const          previous_verbose = ::tts::_::current_verbosity.verbose;
-  bool const          previous_quiet   = ::tts::_::current_verbosity.quiet;
+  ::tts::_::verbosity_scope scope;
 
-  tts::gathering_sink gs;
-  auto&               out      = tts::output();
-  auto&               previous = out.sink();
+  tts::gathering_sink       gs;
+  auto&                     out      = tts::output();
+  auto&                     previous = out.sink();
   out.sink(gs);
 
   ::tts::_::current_verbosity.verbose = false;
@@ -167,6 +196,4 @@ TTS_CASE("Check report_fatal shares the same type hint behavior as report_fail")
   TTS_EQUAL(gs.content(), "  [@] [loc] : @@ FATAL @@ : msg\n");
 
   out.sink(previous);
-  ::tts::_::current_verbosity.verbose = previous_verbose;
-  ::tts::_::current_verbosity.quiet   = previous_quiet;
 };

--- a/test/unit/infrastructure/output.cpp
+++ b/test/unit/infrastructure/output.cpp
@@ -1,0 +1,74 @@
+//==================================================================================================
+/**
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+#include <tts/tts.hpp>
+
+TTS_CASE("Check output_handler defaults to tts::output_handler::default_sink")
+{
+  TTS_EXPECT(&tts::output().sink() == &tts::output_handler::default_sink());
+};
+
+TTS_CASE("Check gathering_sink accumulates written text instead of streaming it")
+{
+  tts::gathering_sink gs;
+  auto&               out      = tts::output();
+  auto&               previous = out.sink();
+
+  out.sink(gs);
+  out.write("Hello ");
+  out.write("World %d", 42);
+  out.writeln("!");
+  out.sink(previous);
+
+  TTS_EQUAL(gs.content(), "Hello World 42!\n");
+};
+
+TTS_CASE("Check gathering_sink::clear discards gathered content")
+{
+  tts::gathering_sink gs;
+  gs.write(tts::text {"some text"});
+  TTS_EXPECT_NOT(gs.content().is_empty());
+
+  gs.clear();
+  TTS_EXPECT(gs.content().is_empty());
+};
+
+TTS_CASE("Check gathering_sink::dump streams then clears the gathered content")
+{
+  tts::gathering_sink gs;
+  gs.write(tts::text {"dumped content\n"});
+
+  gs.dump();
+
+  TTS_EXPECT(gs.content().is_empty());
+};
+
+TTS_CASE("Check output_handler dispatches to a power user defined output_sink")
+{
+  struct counting_sink : tts::output_sink
+  {
+    int       calls = 0;
+    tts::text last;
+
+    void      write(tts::text const& t) override
+    {
+      calls++;
+      last = t;
+    }
+  };
+
+  counting_sink custom;
+  auto&         out      = tts::output();
+  auto&         previous = out.sink();
+
+  out.sink(custom);
+  out.write("custom output");
+  out.sink(previous);
+
+  TTS_EQUAL(custom.calls, 1);
+  TTS_EQUAL(custom.last, "custom output");
+};


### PR DESCRIPTION
Sinks can be defined and used in custom driver so that the output of tests can be processed as needed.