### PR TITLE
Remove unused buffer constructor template

### DIFF
--- a/include/tts/tools/buffer.hpp
+++ b/include/tts/tools/buffer.hpp
@@ -51,7 +51,6 @@ namespace tts
       }
     }
 
-    template<typename... Ts>
     buffer(std::initializer_list<T> init)
         : buffer()
     {


### PR DESCRIPTION
## Summary

- remove the unused template parameter pack from `buffer`'s initializer-list constructor
- preserve the existing initializer-list behavior and test coverage

Closes #158

## Validation

- `pre-commit run --all-files`
- existing `test/unit/infrastructure/buffer.cpp` initializer-list coverage (upstream CI)

Assisted-by: OpenAI Codex