### PR TITLE
Fix #152 - TTS_ALL_EQUAL fails to compile with REQUIRED

### DIFF
--- a/include/tts/test/sequence.hpp
+++ b/include/tts/test/sequence.hpp
@@ -228,7 +228,7 @@ overload.
 #if defined(TTS_DOXYGEN_INVOKED)
 #define TTS_ALL_EQUAL(L, R, ...)
 #else
-#define TTS_ALL_EQUAL(L, R, ...) TTS_ALL_ABSOLUTE_EQUAL(L, R, 0 __VA_ARGS__)
+#define TTS_ALL_EQUAL(L, R, ...) TTS_ALL_ABSOLUTE_EQUAL(L, R, 0, __VA_ARGS__)
 #endif
 
 //======================================================================================================================

--- a/test/unit/tests/sequence.cpp
+++ b/test/unit/tests/sequence.cpp
@@ -20,6 +20,7 @@ TTS_CASE("Equality over sequence")
   TTS_ALL_ABSOLUTE_EQUAL(v, v, 0);
   TTS_ALL_ABSOLUTE_EQUAL(v, w, 0);
   TTS_ALL_ABSOLUTE_EQUAL(v, z, 3);
+  TTS_ALL_ABSOLUTE_EQUAL(v, w, 0, REQUIRED);
 };
 
 TTS_CASE("Exact equality over sequence")
@@ -29,6 +30,7 @@ TTS_CASE("Exact equality over sequence")
 
   TTS_ALL_EQUAL(v, v);
   TTS_ALL_EQUAL(v, w);
+  TTS_ALL_EQUAL(v, w, REQUIRED);
 };
 
 TTS_CASE("Relative equality over sequence")
@@ -40,6 +42,7 @@ TTS_CASE("Relative equality over sequence")
   TTS_ALL_RELATIVE_EQUAL(v, v, 0);
   TTS_ALL_RELATIVE_EQUAL(v, w, 0);
   TTS_ALL_RELATIVE_EQUAL(v, z, 3.33);
+  TTS_ALL_RELATIVE_EQUAL(v, w, 0, REQUIRED);
 };
 
 TTS_CASE("ULP equality over sequence")
@@ -51,6 +54,7 @@ TTS_CASE("ULP equality over sequence")
   TTS_ALL_ULP_EQUAL(v, v, 0);
   TTS_ALL_ULP_EQUAL(v, w, 0.5);
   TTS_ALL_ULP_EQUAL(v, z, 10);
+  TTS_ALL_ULP_EQUAL(v, w, 0.5, REQUIRED);
 };
 
 TTS_CASE("Strict IEEE equality over sequence")
@@ -60,4 +64,5 @@ TTS_CASE("Strict IEEE equality over sequence")
 
   TTS_ALL_IEEE_EQUAL(v, v);
   TTS_ALL_IEEE_EQUAL(v, w);
+  TTS_ALL_IEEE_EQUAL(v, w, REQUIRED);
 };


### PR DESCRIPTION
Missing comma before __VA_ARGS__ in TTS_ALL_EQUAL's definition concatenated the REQUIRED tag into the preceding macro argument. Add REQUIRED coverage for every TTS_ALL_* macro in sequence.cpp so this class of bug gets caught at compile time going forward.