### PR TITLE
Fix #151 - tts::between generator returns wrong values for a descending range

### DIFF
--- a/include/tts/engine/generator.hpp
+++ b/include/tts/engine/generator.hpp
@@ -487,8 +487,11 @@ namespace tts
       (sz - 1)
          ? static_cast<D>(convert_as(last_ - first_, type<D> {}) / convert_as(sz - 1, type<D> {}))
          : convert_as(0, type<D> {});
-      return _::min(
-      convert_as(w1 + convert_as(idx, type<D> {}) * convert_as(step, type<D> {}), type<D> {}), w2);
+      auto value =
+      convert_as(w1 + convert_as(idx, type<D> {}) * convert_as(step, type<D> {}), type<D> {});
+
+      // Clamp rounding overshoot back to the last bound, whichever direction the range runs in.
+      return (w1 <= w2) ? _::min(value, w2) : _::max(value, w2);
     }
 
     template<typename D> D operator()(tts::type<D>) const

--- a/test/unit/tests/generator.cpp
+++ b/test/unit/tests/generator.cpp
@@ -64,8 +64,8 @@ TTS_CASE("Check tts::between supports both ascending and descending ranges")
   tts::between ascending {-4.0, 4.0};
   tts::between descending {10.0, 0.0};
 
-  double       ascending_ref[]  = {-4., -2., 0., 2., 4.};
-  double       descending_ref[] = {10., 7.5, 5., 2.5, 0.};
+  double       ascending_ref[]  = {-4., -2., 0., 2., 4.};  // NOSONAR
+  double       descending_ref[] = {10., 7.5, 5., 2.5, 0.}; // NOSONAR
 
   for(std::size_t i = 0; i < 5; ++i)
   {

--- a/test/unit/tests/generator.cpp
+++ b/test/unit/tests/generator.cpp
@@ -59,6 +59,21 @@ TTS_CASE_WITH("Check behavior for scalar types",
   TTS_LESS_EQUAL(rng, T(100));
 };
 
+TTS_CASE("Check tts::between supports both ascending and descending ranges")
+{
+  tts::between ascending {-4.0, 4.0};
+  tts::between descending {10.0, 0.0};
+
+  double       ascending_ref[]  = {-4., -2., 0., 2., 4.};
+  double       descending_ref[] = {10., 7.5, 5., 2.5, 0.};
+
+  for(std::size_t i = 0; i < 5; ++i)
+  {
+    TTS_ULP_EQUAL(ascending(tts::type<double> {}, i, 5UL), ascending_ref[ i ], 0.5);
+    TTS_ULP_EQUAL(descending(tts::type<double> {}, i, 5UL), descending_ref[ i ], 0.5);
+  }
+};
+
 TTS_CASE_WITH("Check behavior for non-scalar types",
               array_of<::tts::arithmetic_types>,
               tts::value {37},


### PR DESCRIPTION
`between`'s rounding-overshoot clamp unconditionally used `min(value, last)`, which assumes an ascending range. For a descending range (`first > last`) that clamps every sample down to `last` instead of producing a ramp. Now picks `min` or `max` depending on which way the range actually runs, symmetric with how `tts::_::roll()` already handles `M > N`.