### PR TITLE
Fix #159, #163 - tts::buffer const operator[] and capacity overflow guard

### DIFF
--- a/include/tts/tools/buffer.hpp
+++ b/include/tts/tools/buffer.hpp
@@ -134,7 +134,7 @@ namespace tts
       new(data_ + size_++) T(TTS_FWD(args)...);
     }
 
-    T operator[](std::size_t i) const
+    T const& operator[](std::size_t i) const
     {
       return data_[ i ];
     }
@@ -198,9 +198,15 @@ namespace tts
     {
       if(new_capacity > capacity_)
       {
+        assert(capacity_ <= std::numeric_limits<std::size_t>::max() / 2 &&
+               "tts::buffer requested capacity overflows size_t");
         std::size_t new_cap = capacity_ == 0 ? 1 : capacity_ * 2;
         while(new_cap < new_capacity)
+        {
+          assert(new_cap <= std::numeric_limits<std::size_t>::max() / 2 &&
+                 "tts::buffer requested capacity overflows size_t");
           new_cap *= 2;
+        }
 
         auto new_data = static_cast<T*>(malloc(sizeof(T) * new_cap)); // NOSONAR
         assert(new_data && "tts::buffer out of memory");

--- a/test/unit/infrastructure/buffer.cpp
+++ b/test/unit/infrastructure/buffer.cpp
@@ -162,3 +162,32 @@ TTS_CASE("Check buffer with non trivially destructible type")
 
   TTS_EQUAL(dtor_count, 3);
 };
+
+TTS_CASE("Check const operator[] returns a reference, not a copy")
+{
+  tts::buffer<int>        b(3);
+  tts::buffer<int> const& cb = b;
+
+  b[ 1 ]                     = 42;
+
+  TTS_EQUAL(&cb[ 1 ], &b[ 1 ]);
+  TTS_EQUAL(cb[ 1 ], 42);
+};
+
+TTS_CASE("Check const operator[] works for a non-copyable type")
+{
+  struct non_copyable
+  {
+    non_copyable()                               = default;
+    non_copyable(non_copyable const&)            = delete;
+    non_copyable& operator=(non_copyable const&) = delete;
+    int           value                          = 0;
+  };
+
+  tts::buffer<non_copyable>        b(1);
+  tts::buffer<non_copyable> const& cb = b;
+
+  b[ 0 ].value                        = 69;
+
+  TTS_EQUAL(cb[ 0 ].value, 69);
+};


### PR DESCRIPTION
`buffer<T>::operator[] const` returned `T` by value instead of `T const&`, forcing an unneeded copy on every const access and making it unusable for non-copyable `T`. `ensure_capacity`'s doubling loop also had no guard against `size_t` overflow for a pathologically large requested capacity - added an assert before each doubling, consistent with the existing out-of-memory assert in the same function.