### PR TITLE
Fix #165 - Report the random seed used by default

### DIFF
--- a/include/tts/engine/main.hpp
+++ b/include/tts/engine/main.hpp
@@ -120,7 +120,10 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
 
   auto        nb_tests   = ::tts::_::suite().size();
   std::size_t done_tests = 0;
-  ::tts::set_random_seed(static_cast<std::uint64_t>(tts::random_seed()));
+  auto        seed       = ::tts::random_seed();
+  ::tts::set_random_seed(static_cast<std::uint64_t>(seed));
+  ::tts::output().writeln(
+  "Random seed: %d (rerun with --seed=%d to reproduce this run)", seed, seed);
 
   try
   {

--- a/test/unit/tests/seed_reporting.cpp
+++ b/test/unit/tests/seed_reporting.cpp
@@ -1,0 +1,35 @@
+//==================================================================================================
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#define TTS_MAIN
+#define TTS_CUSTOM_DRIVER_FUNCTION seed_reporting_main
+#include <tts/tts.hpp>
+#include <string_view>
+
+TTS_CASE("Dummy test so the driver has something to run")
+{
+  TTS_EXPECT(1 == 1);
+};
+
+int main(int argc, char const** argv)
+{
+  ::tts::initialize(argc, argv);
+
+  tts::gathering_sink gs;
+  tts::output().sink(gs);
+
+  seed_reporting_main(argc, argv);
+
+  tts::output().sink(tts::output_handler::default_sink());
+
+  tts::text        needle {"Random seed: %d", tts::random_seed()};
+  std::string_view captured {gs.content().data()};
+
+  TTS_EXPECT(captured.find(needle.data()) != std::string_view::npos);
+
+  return tts::report(0, 0);
+}


### PR DESCRIPTION
The default driver now prints the PRNG seed it's using (`Random seed: N (rerun with --seed=N to reproduce this run)`) right before running the suite, so a flaky failure driven by `tts::randoms`/`tts::random_bits`/ULP range checks can always be reproduced from a CI log without needing a custom driver.