### PR TITLE
Fix #166 - tts::report fails on an empty test suite

### DIFF
--- a/include/tts/engine/environment.hpp
+++ b/include/tts/engine/environment.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <tts/engine/deps.hpp>
+#include <tts/tools/options.hpp>
 #include <tts/tools/output.hpp>
 
 //======================================================================================================================
@@ -71,6 +72,8 @@ namespace tts::_
                   inv_txt);
 
       out.writeln();
+
+      if(test_count == 0 && !::tts::arguments()("--allow-empty")) return 1;
 
       if(!fails && !invalids) return test_count == success_count ? 0 : 1;
       else return (failure_count == fails && invalid_count == invalids) ? 0 : 1;

--- a/include/tts/engine/usage.hpp
+++ b/include/tts/engine/usage.hpp
@@ -17,6 +17,7 @@ Flags:
   -s, --scientific  Print the floating results in scientific mode
   -v, --verbose     Display tests results regardless of their status.
   -q, --quiet       Display only test failures percentage.
+  --allow-empty     Do not fail when the test suite registered zero test.
 
 Parameters:
   --precision=arg   Set the precision for displaying floating pint values

--- a/test/unit/tests/empty_suite.cpp
+++ b/test/unit/tests/empty_suite.cpp
@@ -8,6 +8,7 @@
 #define TTS_MAIN
 #define TTS_CUSTOM_DRIVER_FUNCTION empty_suite_main
 #include <tts/tts.hpp>
+#include <array>
 
 // No TTS_CASE registered on purpose: this file's driver runs an empty suite.
 
@@ -16,10 +17,10 @@ int main(int argc, char const** argv)
   ::tts::initialize(argc, argv);
   empty_suite_main(argc, argv);
 
-  bool        fails_by_default = (::tts::report(0, 0) != 0);
+  bool                       fails_by_default = (::tts::report(0, 0) != 0);
 
-  char const* allow_argv[]     = {argv[ 0 ], "--allow-empty"};
-  ::tts::_::current_arguments  = ::tts::options {2, allow_argv};
+  std::array<char const*, 2> allow_argv {argv[ 0 ], "--allow-empty"};
+  ::tts::_::current_arguments  = ::tts::options {2, allow_argv.data()};
 
   bool passes_with_allow_empty = (::tts::report(0, 0) == 0);
 

--- a/test/unit/tests/empty_suite.cpp
+++ b/test/unit/tests/empty_suite.cpp
@@ -1,0 +1,30 @@
+//==================================================================================================
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#define TTS_MAIN
+#define TTS_CUSTOM_DRIVER_FUNCTION empty_suite_main
+#include <tts/tts.hpp>
+
+// No TTS_CASE registered on purpose: this file's driver runs an empty suite.
+
+int main(int argc, char const** argv)
+{
+  ::tts::initialize(argc, argv);
+  empty_suite_main(argc, argv);
+
+  bool        fails_by_default = (::tts::report(0, 0) != 0);
+
+  char const* allow_argv[]     = {argv[ 0 ], "--allow-empty"};
+  ::tts::_::current_arguments  = ::tts::options {2, allow_argv};
+
+  bool passes_with_allow_empty = (::tts::report(0, 0) == 0);
+
+  TTS_EXPECT(fails_by_default);
+  TTS_EXPECT(passes_with_allow_empty);
+
+  return ::tts::report(0, 0);
+}


### PR DESCRIPTION
A test binary that registers zero `TTS_CASE` now exits non-zero instead of silently reporting success — an empty suite is usually the symptom of a build/link/registration bug (wrong object file linked, a macro that silently failed to expand, a typo'd file glob in CMake, ...) that CI would otherwise miss entirely. The `--allow-empty` flag opts back into the old behavior for legitimately empty suites (e.g. platform-gated tests).