### PR TITLE
Fix #150 - relative_check treats NaN as equal to any value

### DIFF
--- a/include/tts/tools/precision.hpp
+++ b/include/tts/tools/precision.hpp
@@ -98,7 +98,7 @@ namespace tts
       }
       else if constexpr(std::is_floating_point_v<T>) // IEEE cases
       {
-        if((a == b) || (_::is_nan(a) && _::is_nan(a))) return 0.;
+        if((a == b) || (_::is_nan(a) && _::is_nan(b))) return 0.;
 
         if(_::is_inf(a) || _::is_inf(b) || _::is_nan(a) || _::is_nan(b))
           return std::numeric_limits<double>::infinity();

--- a/test/unit/precision/relative.cpp
+++ b/test/unit/precision/relative.cpp
@@ -76,6 +76,18 @@ TTS_CASE_TPL("Relative distance between floating point", float, double)
 #endif
 };
 
+TTS_CASE("relative_check treats exactly one NaN operand as infinitely far")
+{
+#if !defined(__FAST_MATH__)
+  double qnan = std::numeric_limits<double>::quiet_NaN();
+  double inf  = std::numeric_limits<double>::infinity();
+
+  TTS_EQUAL(tts::relative_check(qnan, 5.), inf);
+  TTS_EQUAL(tts::relative_check(5., qnan), inf);
+  TTS_EQUAL(tts::relative_check(qnan, qnan), 0.);
+#endif
+};
+
 #include "my_real.hpp"
 
 TTS_CASE("Relative distance of type with custom reldist")

--- a/test/unit/precision/relative.cpp
+++ b/test/unit/precision/relative.cpp
@@ -6,6 +6,7 @@
 */
 //==================================================================================================
 #include <tts/tts.hpp>
+#include <cmath>
 
 TTS_CASE("Relative distance")
 {
@@ -80,10 +81,9 @@ TTS_CASE("relative_check treats exactly one NaN operand as infinitely far")
 {
 #if !defined(__FAST_MATH__)
   double qnan = std::numeric_limits<double>::quiet_NaN();
-  double inf  = std::numeric_limits<double>::infinity();
 
-  TTS_EQUAL(tts::relative_check(qnan, 5.), inf);
-  TTS_EQUAL(tts::relative_check(5., qnan), inf);
+  TTS_EXPECT(!std::isfinite(tts::relative_check(qnan, 5.)));
+  TTS_EXPECT(!std::isfinite(tts::relative_check(5., qnan)));
   TTS_EQUAL(tts::relative_check(qnan, qnan), 0.);
 #endif
 };


### PR DESCRIPTION
`relative_check(a, b)` tested `is_nan(a) && is_nan(a)` instead of `is_nan(a) && is_nan(b)`, so it silently returned `0.` (i.e. "equal") whenever `a` was NaN, regardless of `b`. `absolute_check`/`ulp_check` right next to it already had the correct pattern. Now `relative_check` returns `+inf` when exactly one operand is NaN, matching the other precision checks.

The existing NaN coverage in `test/unit/precision/relative.cpp` didn't catch this because `TTS_RELATIVE_EQUAL` checks `relative_check(...) <= tolerance`, and `0 <= inf` passes either way. Added a direct check on `tts::relative_check`'s return value instead.