### PR TITLE
Fix #160 - route main.hpp's flushes through the output_sink abstraction

### DIFF
--- a/include/tts/engine/main.hpp
+++ b/include/tts/engine/main.hpp
@@ -134,7 +134,7 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
       ::tts::global_runtime.fail_status = false;
 
       if(!::tts::is_quiet()) ::tts::output().writeln("TEST: '%s'", t.name);
-      fflush(stdout);
+      ::tts::output().flush();
       t();
       done_tests++;
 
@@ -142,12 +142,12 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
       {
         ::tts::global_runtime.invalid();
         if(!::tts::is_quiet()) ::tts::output().writeln("  [!!]: EMPTY TEST CASE");
-        fflush(stdout);
+        ::tts::output().flush();
       }
       else if(failure_count == ::tts::global_runtime.failure_count)
       {
         if(!::tts::is_quiet()) ::tts::output().writeln("TEST: '%s' - [PASSED]", t.name);
-        fflush(stdout);
+        ::tts::output().flush();
       }
     }
   }

--- a/include/tts/tools/output.hpp
+++ b/include/tts/tools/output.hpp
@@ -94,7 +94,13 @@ namespace tts
   {
     /// Writes t to this sink's destination.
     virtual void write(text const& t) = 0;
-    virtual ~output_sink()            = default;
+
+    /// Flushes this sink's destination, if that means anything for it. No-op by default.
+    virtual void flush()
+    {
+    }
+
+    virtual ~output_sink() = default;
   };
 
   //====================================================================================================================
@@ -111,6 +117,11 @@ namespace tts
     void write(text const& t) override
     {
       fputs(t.data(), stdout);
+    }
+
+    void flush() override
+    {
+      fflush(stdout);
     }
   };
 
@@ -224,6 +235,12 @@ namespace tts
     template<typename... Args> void writeln(char const* format, Args const&... args)
     {
       writeln(text(format, args...));
+    }
+
+    /// Flushes the current output_sink, if that means anything for it.
+    void flush()
+    {
+      sink_->flush();
     }
 
     /// Installs s as the output_sink every subsequent write goes to.

--- a/include/tts/tools/output.hpp
+++ b/include/tts/tools/output.hpp
@@ -98,6 +98,7 @@ namespace tts
     /// Flushes this sink's destination, if that means anything for it. No-op by default.
     virtual void flush()
     {
+      // Intentionally empty: most sinks (e.g. gathering_sink) have nothing meaningful to flush.
     }
 
     virtual ~output_sink() = default;

--- a/test/unit/infrastructure/output.cpp
+++ b/test/unit/infrastructure/output.cpp
@@ -182,6 +182,7 @@ TTS_CASE("Check output_handler::flush dispatches to the current output_sink")
     int  flushes = 0;
     void write(tts::text const&) override
     {
+      // Unused: this test only exercises flush().
     }
     void flush() override
     {

--- a/test/unit/infrastructure/output.cpp
+++ b/test/unit/infrastructure/output.cpp
@@ -175,6 +175,41 @@ TTS_CASE("Check output_handler dispatches to a power user defined output_sink")
   TTS_EQUAL(custom.last, "custom output");
 };
 
+TTS_CASE("Check output_handler::flush dispatches to the current output_sink")
+{
+  struct flushable_sink : tts::output_sink
+  {
+    int  flushes = 0;
+    void write(tts::text const&) override
+    {
+    }
+    void flush() override
+    {
+      flushes++;
+    }
+  };
+
+  flushable_sink sink;
+  auto&          out      = tts::output();
+  auto&          previous = out.sink();
+
+  out.sink(sink);
+  out.flush();
+  out.sink(previous);
+
+  TTS_EQUAL(sink.flushes, 1);
+};
+
+TTS_CASE("Check output_sink::flush defaults to a no-op")
+{
+  tts::gathering_sink gs;
+  gs.write(tts::text {"kept"});
+
+  gs.flush();
+
+  TTS_EQUAL(gs.content(), "kept");
+};
+
 TTS_CASE("Check report_fail only shows the failing type outside verbose mode")
 {
   ::tts::_::verbosity_scope scope;


### PR DESCRIPTION
`TTS_CUSTOM_DRIVER_FUNCTION`'s body called `fflush(stdout)` directly, which is meaningless once a non-stdout `tts::output_sink` (e.g. `tts::gathering_sink` or a custom one) is installed - the flush targets a stream nothing was written to.

`output_sink` gains an optional `flush()` hook (no-op by default, so existing custom sinks keep compiling unchanged), `stdout_sink` overrides it to call `fflush(stdout)`, and `output_handler::flush()` forwards to the currently installed sink. The default driver now calls `tts::output().flush()` instead of the raw libc call.