### PR TITLE
Add tts::scoped_sink to install/restore an output_sink via RAII

### DIFF
--- a/include/tts/tools/output.hpp
+++ b/include/tts/tools/output.hpp
@@ -44,21 +44,21 @@ namespace tts::_
   // tests that need to exercise a specific verbose/quiet combination without leaking that state
   // into the rest of the running test suite, even if the test exits early.
   //====================================================================================================================
-  struct verbosity_scope
+  struct scoped_verbosity
   {
-    verbosity_scope() = default;
+    scoped_verbosity() = default;
 
-    ~verbosity_scope()
+    ~scoped_verbosity()
     {
       current_verbosity = saved;
     }
 
-    verbosity_scope(verbosity_scope const&)            = delete;
-    verbosity_scope& operator=(verbosity_scope const&) = delete;
-    verbosity_scope(verbosity_scope&&)                 = delete;
-    verbosity_scope& operator=(verbosity_scope&&)      = delete;
+    scoped_verbosity(scoped_verbosity const&)            = delete;
+    scoped_verbosity& operator=(scoped_verbosity const&) = delete;
+    scoped_verbosity(scoped_verbosity&&)                 = delete;
+    scoped_verbosity& operator=(scoped_verbosity&&)      = delete;
 
-    verbosity        saved                             = current_verbosity;
+    verbosity         saved                              = current_verbosity;
   };
 }
 
@@ -284,6 +284,45 @@ namespace tts
   {
     return _::current_output;
   }
+
+  //====================================================================================================================
+  /**
+    @public
+    @brief RAII guard installing an output_sink for its scope, restoring the previous one on exit.
+
+    Saves whichever output_sink is currently installed on tts::output(), installs `s`, then restores
+    the saved one once the guard goes out of scope - even through an early return or an exception.
+
+    @groupheader{Example}
+    @snippet doc/custom_output_sink.cpp snippet
+
+    @see tts::output_sink
+    @see tts::output_handler
+  **/
+  //====================================================================================================================
+  class scoped_sink
+  {
+  public:
+    /// Installs s as the current output_sink, saving whichever one was previously installed.
+    explicit scoped_sink(output_sink& s)
+        : saved_(output().sink())
+    {
+      output().sink(s);
+    }
+
+    ~scoped_sink()
+    {
+      output().sink(saved_);
+    }
+
+    scoped_sink(scoped_sink const&)            = delete;
+    scoped_sink& operator=(scoped_sink const&) = delete;
+    scoped_sink(scoped_sink&&)                 = delete;
+    scoped_sink& operator=(scoped_sink&&)      = delete;
+
+  private:
+    output_sink& saved_;
+  };
 
   //====================================================================================================================
   //! @}

--- a/include/tts/tools/output.hpp
+++ b/include/tts/tools/output.hpp
@@ -305,7 +305,6 @@ namespace tts
   public:
     /// Installs s as the current output_sink, saving whichever one was previously installed.
     explicit scoped_sink(output_sink& s)
-        : saved_(output().sink())
     {
       output().sink(s);
     }
@@ -321,7 +320,7 @@ namespace tts
     scoped_sink& operator=(scoped_sink&&)      = delete;
 
   private:
-    output_sink& saved_;
+    output_sink& saved_ = output().sink();
   };
 
   //====================================================================================================================

--- a/test/unit/doc/custom_output_sink.cpp
+++ b/test/unit/doc/custom_output_sink.cpp
@@ -34,11 +34,10 @@ int main(int argc, char const** argv)
   ::tts::initialize(argc, argv);
 
   prefixed_sink sink;
-  tts::output().sink(sink); // Install our custom sink...
-
-  custom_sink_main(argc, argv); // ...run the test suite through it...
-
-  tts::output().sink(tts::output_handler::default_sink()); // ...then restore the default one.
+  {
+    tts::scoped_sink scope(sink); // Install our custom sink for this scope...
+    custom_sink_main(argc, argv); // ...run the test suite through it...
+  } // ...then automatically restore the previous one.
 
   printf("Our custom output_sink received %d message(s)\n", sink.messages);
 

--- a/test/unit/infrastructure/output.cpp
+++ b/test/unit/infrastructure/output.cpp
@@ -9,7 +9,7 @@
 
 TTS_CASE("Check set_verbose and set_quiet are the only writers of current_verbosity")
 {
-  ::tts::_::verbosity_scope scope;
+  ::tts::_::scoped_verbosity scope;
 
   ::tts::_::set_verbose(false);
   ::tts::_::set_quiet(false);
@@ -29,15 +29,15 @@ TTS_CASE("Check set_verbose and set_quiet are the only writers of current_verbos
   TTS_EXPECT(::tts::_::current_verbosity.quiet);
 };
 
-TTS_CASE("Check verbosity_scope saves and restores current_verbosity")
+TTS_CASE("Check scoped_verbosity saves and restores current_verbosity")
 {
-  ::tts::_::verbosity_scope outer; // restores whatever was in place before this test ran
+  ::tts::_::scoped_verbosity outer; // restores whatever was in place before this test ran
 
   ::tts::_::set_verbose(false);
   ::tts::_::set_quiet(true);
 
   {
-    ::tts::_::verbosity_scope inner;
+    ::tts::_::scoped_verbosity inner;
     ::tts::_::set_verbose(true);
     ::tts::_::set_quiet(false);
     TTS_EXPECT(tts::is_verbose());
@@ -50,7 +50,7 @@ TTS_CASE("Check verbosity_scope saves and restores current_verbosity")
 
 TTS_CASE("Check is_verbose and is_quiet reflect the current verbosity state")
 {
-  ::tts::_::verbosity_scope scope;
+  ::tts::_::scoped_verbosity scope;
 
   ::tts::_::set_verbose(false);
   ::tts::_::set_quiet(false);
@@ -68,7 +68,7 @@ TTS_CASE("Check is_verbose and is_quiet reflect the current verbosity state")
 
 TTS_CASE("Check is_detailed is true only when verbose is set and quiet is not")
 {
-  ::tts::_::verbosity_scope scope;
+  ::tts::_::scoped_verbosity scope;
 
   ::tts::_::set_verbose(false);
   ::tts::_::set_quiet(false);
@@ -90,9 +90,7 @@ TTS_CASE("Check is_detailed is true only when verbose is set and quiet is not")
 TTS_CASE("Check separator writes an 80-dash line only when printable is true")
 {
   tts::gathering_sink gs;
-  auto&               out      = tts::output();
-  auto&               previous = out.sink();
-  out.sink(gs);
+  tts::scoped_sink    scope(gs);
 
   ::tts::_::separator(false);
   TTS_EXPECT(gs.content().is_empty());
@@ -105,8 +103,6 @@ TTS_CASE("Check separator writes an 80-dash line only when printable is true")
   ::tts::_::separator();
   TTS_EQUAL(gs.content(),
             "--------------------------------------------------------------------------------\n");
-
-  out.sink(previous);
 };
 
 TTS_CASE("Check output_handler defaults to tts::output_handler::default_sink")
@@ -117,14 +113,14 @@ TTS_CASE("Check output_handler defaults to tts::output_handler::default_sink")
 TTS_CASE("Check gathering_sink accumulates written text instead of streaming it")
 {
   tts::gathering_sink gs;
-  auto&               out      = tts::output();
-  auto&               previous = out.sink();
+  auto&               out = tts::output();
 
-  out.sink(gs);
-  out.write("Hello ");
-  out.write("World %d", 42);
-  out.writeln("!");
-  out.sink(previous);
+  {
+    tts::scoped_sink scope(gs);
+    out.write("Hello ");
+    out.write("World %d", 42);
+    out.writeln("!");
+  }
 
   TTS_EQUAL(gs.content(), "Hello World 42!\n");
 };
@@ -191,14 +187,52 @@ TTS_CASE("Check output_handler::flush dispatches to the current output_sink")
   };
 
   flushable_sink sink;
-  auto&          out      = tts::output();
-  auto&          previous = out.sink();
+  auto&          out = tts::output();
 
-  out.sink(sink);
-  out.flush();
-  out.sink(previous);
+  {
+    tts::scoped_sink scope(sink);
+    out.flush();
+  }
 
   TTS_EQUAL(sink.flushes, 1);
+};
+
+TTS_CASE("Check scoped_sink installs a sink and restores the previous one on scope exit")
+{
+  tts::gathering_sink gs;
+  auto&               out      = tts::output();
+  auto&               previous = out.sink();
+
+  {
+    tts::scoped_sink scope(gs);
+    TTS_EQUAL(&out.sink(), &gs);
+    out.write("inside scope");
+  }
+
+  TTS_EQUAL(&out.sink(), &previous);
+  TTS_EQUAL(gs.content(), "inside scope");
+};
+
+TTS_CASE("Check nested scoped_sink instances restore in the right order")
+{
+  tts::gathering_sink outer_gs;
+  tts::gathering_sink inner_gs;
+  auto&               out      = tts::output();
+  auto&               previous = out.sink();
+
+  {
+    tts::scoped_sink outer(outer_gs);
+    {
+      tts::scoped_sink inner(inner_gs);
+      out.write("inner");
+    }
+    TTS_EQUAL(&out.sink(), &outer_gs);
+    out.write("outer");
+  }
+
+  TTS_EQUAL(&out.sink(), &previous);
+  TTS_EQUAL(outer_gs.content(), "outer");
+  TTS_EQUAL(inner_gs.content(), "inner");
 };
 
 TTS_CASE("Check output_sink::flush defaults to a no-op")
@@ -213,12 +247,10 @@ TTS_CASE("Check output_sink::flush defaults to a no-op")
 
 TTS_CASE("Check report_fail only shows the failing type outside verbose mode")
 {
-  ::tts::_::verbosity_scope scope;
+  ::tts::_::scoped_verbosity scope;
 
-  tts::gathering_sink       gs;
-  auto&                     out      = tts::output();
-  auto&                     previous = out.sink();
-  out.sink(gs);
+  tts::gathering_sink        gs;
+  tts::scoped_sink           sink_scope(gs);
 
   // Quiet hides the "[X] ... FAILURE ..." line so only the type hint remains, isolating it.
   ::tts::_::set_verbose(false);
@@ -230,18 +262,14 @@ TTS_CASE("Check report_fail only shows the failing type outside verbose mode")
   ::tts::_::set_verbose(true);
   ::tts::_::report_fail("[loc]", "msg", ::tts::text {"int"});
   TTS_EXPECT(gs.content().is_empty());
-
-  out.sink(previous);
 };
 
 TTS_CASE("Check report_fatal shares the same type hint behavior as report_fail")
 {
-  ::tts::_::verbosity_scope scope;
+  ::tts::_::scoped_verbosity scope;
 
-  tts::gathering_sink       gs;
-  auto&                     out      = tts::output();
-  auto&                     previous = out.sink();
-  out.sink(gs);
+  tts::gathering_sink        gs;
+  tts::scoped_sink           sink_scope(gs);
 
   ::tts::_::set_verbose(false);
   ::tts::_::set_quiet(false);
@@ -252,6 +280,4 @@ TTS_CASE("Check report_fatal shares the same type hint behavior as report_fail")
   ::tts::_::set_verbose(true);
   ::tts::_::report_fatal("[loc]", "msg", ::tts::text {"int"});
   TTS_EQUAL(gs.content(), "  [@] [loc] : @@ FATAL @@ : msg\n");
-
-  out.sink(previous);
 };

--- a/test/unit/tests/seed_reporting.cpp
+++ b/test/unit/tests/seed_reporting.cpp
@@ -20,11 +20,10 @@ int main(int argc, char const** argv)
   ::tts::initialize(argc, argv);
 
   tts::gathering_sink gs;
-  tts::output().sink(gs);
-
-  seed_reporting_main(argc, argv);
-
-  tts::output().sink(tts::output_handler::default_sink());
+  {
+    tts::scoped_sink scope(gs);
+    seed_reporting_main(argc, argv);
+  }
 
   tts::text        needle {"Random seed: %d", tts::random_seed()};
   std::string_view captured {gs.content().data()};


### PR DESCRIPTION
Installing a power-user `output_sink` meant manually saving the current one, installing the new one, then restoring the saved one afterward - repeated by hand in the custom output_sink doc snippet, `seed_reporting.cpp`, and several infrastructure tests.

`tts::scoped_sink` installs a sink for its scope and restores the previous one on destruction, even through an early return or an exception - mirroring `tts::_::scoped_verbosity` (renamed from `verbosity_scope` for consistency with the new name). Updated the doc snippet and the tests that previously did this by hand to use it, while keeping one low-level test exercising `output_handler::sink()`/`sink(s)` directly.