### PR TITLE
Fix #154 - ulp_check can overflow for very large integral values

### DIFF
--- a/include/tts/tools/precision.hpp
+++ b/include/tts/tools/precision.hpp
@@ -179,8 +179,9 @@ namespace tts
       {
         using u_t = typename std::make_unsigned<T>::type;
 
-        // TODO: Fix overflow in case of very huge integral value
-        return static_cast<double>((a < b) ? u_t(b - a) : u_t(a - b)) / 2.;
+        auto ua   = static_cast<u_t>(a);
+        auto ub   = static_cast<u_t>(b);
+        return static_cast<double>((a < b) ? (ub - ua) : (ua - ub)) / 2.;
       }
       else
       {

--- a/test/unit/precision/ulp.cpp
+++ b/test/unit/precision/ulp.cpp
@@ -82,6 +82,17 @@ TTS_CASE_TPL("ULP distance between floating points", double, float)
 #endif
 };
 
+TTS_CASE("ULP distance avoids signed overflow near a large integral type's limits")
+{
+  auto lo       = std::numeric_limits<std::int64_t>::min();
+  auto hi       = std::numeric_limits<std::int64_t>::max();
+
+  auto expected = static_cast<double>(std::numeric_limits<std::uint64_t>::max()) / 2.;
+
+  TTS_EQUAL(tts::ulp_check(lo, hi), expected);
+  TTS_EQUAL(tts::ulp_check(hi, lo), expected);
+};
+
 #include "my_real.hpp"
 
 TTS_CASE("ULP distance of type with custom ulpdist")


### PR DESCRIPTION
The integral branch of `ulp_check` computed `b - a` / `a - b` in `T`'s own (possibly signed) arithmetic before casting to unsigned - undefined behavior for large signed types near their limits (e.g. `INT64_MIN` vs `INT64_MAX`), confirmed with UBSan (`signed integer overflow: 9223372036854775807 - -9223372036854775808 cannot be represented in type 'long int'`).

Casting both operands to the unsigned type before subtracting keeps the whole computation in well-defined modular arithmetic, same technique used for the buffer capacity overflow guard in #159/#163.