### PR TITLE
Fix #161 - gathering_sink::dump() always writes to stdout

### DIFF
--- a/include/tts/tools/output.hpp
+++ b/include/tts/tools/output.hpp
@@ -142,7 +142,9 @@ namespace tts
 
     // ... run the test suite ...
 
-    report.dump();                        // stream everything gathered so far at once
+    report.dump();                        // stream everything gathered so far to stdout
+    // or
+    report.dump(some_other_sink);         // forward it to another output_sink instead
     // or
     do_something_with(report.content());  // retrieve it to do something else entirely
     @endcode
@@ -161,11 +163,18 @@ namespace tts
       return buffer_;
     }
 
+    /// Forwards everything gathered so far to target, then clears the buffer.
+    void dump(output_sink& target)
+    {
+      target.write(buffer_);
+      clear();
+    }
+
     /// Streams everything gathered so far to `stdout`, then clears the buffer.
     void dump()
     {
-      fputs(buffer_.data(), stdout);
-      clear();
+      stdout_sink target;
+      dump(target);
     }
 
     /// Discards everything gathered so far.

--- a/test/unit/infrastructure/output.cpp
+++ b/test/unit/infrastructure/output.cpp
@@ -145,6 +145,18 @@ TTS_CASE("Check gathering_sink::dump streams then clears the gathered content")
   TTS_EXPECT(gs.content().is_empty());
 };
 
+TTS_CASE("Check gathering_sink::dump(sink) forwards content to it then clears the source")
+{
+  tts::gathering_sink source;
+  tts::gathering_sink target;
+
+  source.write(tts::text {"forwarded content"});
+  source.dump(target);
+
+  TTS_EQUAL(target.content(), "forwarded content");
+  TTS_EXPECT(source.content().is_empty());
+};
+
 TTS_CASE("Check output_handler dispatches to a power user defined output_sink")
 {
   struct counting_sink : tts::output_sink


### PR DESCRIPTION
`gathering_sink::dump()` streamed its buffer directly via `fputs(..., stdout)`, bypassing any other `tts::output_sink` a user might want to forward the captured content to (a file sink, or another `gathering_sink` for composition).

Added a `dump(output_sink& target)` overload forwarding `content()` to an arbitrary sink then clearing the buffer. The no-arg `dump()` now delegates to it with a local `stdout_sink`, keeping stdout as the convenience default.