### PR TITLE
Add an ASan+UBSan CI wave, running after the normal Linux matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,14 @@ jobs:
     needs: precommit
     uses: ./.github/workflows/linux.yml
 
+  ##################################################################################################
+  ## Sanitizers (ASan+UBSan) - runs after the normal Linux matrix (tests + MemCheck) has passed
+  ##################################################################################################
+  sanitizer-tests:
+    name: Sanitizers
+    needs: linux-tests
+    uses: ./.github/workflows/sanitizers.yml
+
   macos-tests:
     name: MacOS
     needs: precommit

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,37 @@
+##======================================================================================================================
+##  TTS - Tiny Test System
+##  Copyright : TTS Contributors & Maintainers
+##  SPDX-License-Identifier: BSL-1.0
+##======================================================================================================================
+name: TTS Sanitizers
+on:
+  workflow_call:
+
+jobs:
+  sanitizers:
+    name: ${{ matrix.compiler.name }} (ASan+UBSan)
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/jfalcou/compilers:v10
+    strategy:
+      fail-fast: false
+      matrix:
+        compiler:
+          - { name: "gcc"  , preset: "gcc-sanitize"   }
+          - { name: "clang", preset: "clang-sanitize" }
+
+    steps:
+      - name: Fetch current branch
+        uses: actions/checkout@v6
+
+      - name: Configure CMake and Build
+        uses: ./.github/actions/config
+        with:
+          config: Debug
+          preset: ${{ matrix.compiler.preset }}
+
+      - name: Run Unit Tests
+        uses: ./.github/actions/test
+        with:
+          config: Debug
+          preset: ${{ matrix.compiler.preset }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,9 @@ include(${PROJECT_SOURCE_DIR}/cmake/dependencies.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/compiler.cmake)
 
 ##======================================================================================================================
-option( TTS_BUILD_TEST          "Build tests for TTS"   ON  )
-option( TTS_BUILD_DOCUMENTATION "Build Doxygen for TTS" OFF )
+option( TTS_BUILD_TEST          "Build tests for TTS"                                          ON  )
+option( TTS_BUILD_DOCUMENTATION "Build Doxygen for TTS"                                        OFF )
+option( TTS_ENABLE_SANITIZERS   "Build tests with AddressSanitizer + UndefinedBehaviorSanitizer" OFF )
 
 ##======================================================================================================================
 ## Project setup via copacabana
@@ -33,6 +34,7 @@ if(NOT TTS_QUIET)
   endif()
   message(STATUS "[${PROJECT_NAME}] - Unit tests : ${TTS_BUILD_TEST} (via TTS_BUILD_TEST)")
   message(STATUS "[${PROJECT_NAME}] - Doxygen    : ${TTS_BUILD_DOCUMENTATION} (via TTS_BUILD_DOCUMENTATION)")
+  message(STATUS "[${PROJECT_NAME}] - Sanitizers : ${TTS_ENABLE_SANITIZERS} (via TTS_ENABLE_SANITIZERS)")
   set(QUIET_OPTION "")
 else()
   set(QUIET_OPTION "QUIET")
@@ -71,6 +73,10 @@ endif()
 ## Tests setup
 ##======================================================================================================================
 if(TTS_BUILD_TEST)
+  if(TTS_ENABLE_SANITIZERS)
+    copa_setup_sanitizers(tts_test ENABLE_ASAN ENABLE_UBSAN)
+  endif()
+
   include(CTest)
   enable_testing()
   add_custom_target(tts-unit)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -74,6 +74,21 @@
       }
     },
     {
+      "name": "sanitize",
+      "hidden": true,
+      "cacheVariables": {
+        "TTS_ENABLE_SANITIZERS": "ON"
+      }
+    },
+    {
+      "name": "gcc-sanitize",
+      "inherits": ["gcc", "sanitize"]
+    },
+    {
+      "name": "clang-sanitize",
+      "inherits": ["clang", "sanitize"]
+    },
+    {
       "name": "clang-cuda",
       "inherits": ["unix-base"],
       "cacheVariables": {
@@ -139,6 +154,8 @@
     { "name": "gcc"             , "inherits": "base-build", "configurePreset": "gcc"            },
     { "name": "clang"           , "inherits": "base-build", "configurePreset": "clang"          },
     { "name": "clang-libc++"    , "inherits": "base-build", "configurePreset": "clang-libc++"   },
+    { "name": "gcc-sanitize"    , "inherits": "base-build", "configurePreset": "gcc-sanitize"   },
+    { "name": "clang-sanitize"  , "inherits": "base-build", "configurePreset": "clang-sanitize" },
     { "name": "icpx"            , "inherits": "base-build", "configurePreset": "icpx"           },
     { "name": "wasm"            , "inherits": "base-build", "configurePreset": "wasm"           },
     { "name": "android-arm64"   , "inherits": "base-build", "configurePreset": "android-arm64"  },
@@ -155,6 +172,8 @@
     { "name": "gcc"             , "inherits": "base-test", "configurePreset": "gcc"             },
     { "name": "clang"           , "inherits": "base-test", "configurePreset": "clang"           },
     { "name": "clang-libc++"    , "inherits": "base-test", "configurePreset": "clang-libc++"    },
+    { "name": "gcc-sanitize"    , "inherits": "base-test", "configurePreset": "gcc-sanitize"    },
+    { "name": "clang-sanitize"  , "inherits": "base-test", "configurePreset": "clang-sanitize"  },
     { "name": "icpx"            , "inherits": "base-test", "configurePreset": "icpx"            },
     { "name": "wasm"            , "inherits": "base-test", "configurePreset": "wasm"            },
     { "name": "android-arm64"   , "inherits": "base-test", "configurePreset": "android-arm64"   },


### PR DESCRIPTION
copacabana already ships `copa_setup_sanitizers`, unused until now. It's wired up behind a new `TTS_ENABLE_SANITIZERS` option, applied once to the shared `tts_test` interface target so every test executable gets instrumented.

New `gcc-sanitize`/`clang-sanitize` presets and a small `sanitizers.yml` workflow (gcc+clang, Debug only, to keep the matrix from ballooning) run the whole suite under `-fsanitize=address,undefined`. TSan is skipped (TTS is single-threaded) and MSan is skipped (needs an msan-instrumented libc++ the containers don't have). Gated behind `needs: linux-tests` in ci.yml so it only runs once the normal tests and existing valgrind MemCheck wave have passed.