### PR TITLE
Fix #167 (part 1/2) - Add --dry to list registered tests without running them

### DIFF
--- a/doc/cli.hpp
+++ b/doc/cli.hpp
@@ -18,6 +18,40 @@
   `--verbose`     | `-v`     | Display tests results regardless of their status. `./my_test --verbose`
   `--quiet`       | `-q`     | Remove all tests results regardless of their status. `./my_test --quiet`
 
+  # Execution Control
+  These options change what actually gets run and how results are reported, mostly useful for
+  CI integration. Those options have no short form.
+
+  Options           | Description
+  ----------------- | -----------------------------------------------------------------------
+  `--dry`           | Print registered test names without running them. `./my_test --dry`
+  `--allow-empty`   | Do not fail when the test suite registered zero test. `./my_test --allow-empty`
+  `--capture=path`  | Capture this run's output and write it to `path` instead of stdout. `./my_test --capture=report.txt`
+
+  @note `--dry` only prints what's known without running any test: registered @ref TTS_CASE /
+  @ref TTS_CASE_TPL / @ref TTS_CASE_WITH names, plus their types for the latter two. It cannot
+  list @ref TTS_WHEN / @ref TTS_AND_THEN sub-scenarios, since those only exist as runtime control
+  flow inside a test's body - which `--dry` never executes. For example, given:
+
+  @code{cpp}
+  TTS_CASE_TPL("Check stack behavior", std::int32_t, double)
+  <typename T>(::tts::type<T>)
+  {
+    TTS_WHEN("a stack of T is empty")
+    {
+      TTS_AND_THEN("push increases its size") { };
+      TTS_AND_THEN("pop is a no-op")          { };
+    };
+  };
+  @endcode
+
+  `./my_test --dry` prints the case name with its types, but the `WHEN`/`AND_THEN`
+  sub-scenarios stay invisible:
+
+  @code{sh}
+  Check stack behavior <int, double>
+  @endcode
+
   # Tests Parameters
   These options are provided to control the specifics of the tests parameters. Those
   options require a value and have no short form.

--- a/include/tts/engine/case.hpp
+++ b/include/tts/engine/case.hpp
@@ -36,6 +36,24 @@ namespace tts::_
   // Global storage for current type used in a given test
   inline text current_type = {};
 
+  // Builds a ", "-joined list of type names, known at registration time so --dry can display it
+  // without running the test.
+  inline text joined_type_names()
+  {
+    return text {};
+  }
+
+  template<typename T, typename... Rest> inline text joined_type_names()
+  {
+    text out = as_text(typename_<T>);
+    if constexpr(sizeof...(Rest) > 0)
+    {
+      out += ", ";
+      out += joined_type_names<Rest...>();
+    }
+    return out;
+  }
+
   template<typename... Types> struct captures
   {
     captures(char const* id) // NOSONAR
@@ -61,7 +79,8 @@ namespace tts::_
           ...);
          // Clear the current type
          current_type = text {""};
-       }});
+       },
+       joined_type_names<Types...>()});
     }
     char const* name;
   };
@@ -109,7 +128,8 @@ namespace tts::_
                                 {
                                   (process_type<Type>(body), ...);
                                   current_type = text {""};
-                                }});
+                                },
+                                joined_type_names<Type...>()});
     }
   };
 }

--- a/include/tts/engine/main.hpp
+++ b/include/tts/engine/main.hpp
@@ -117,6 +117,13 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
   ::tts::initialize(argc, argv);
   if(::tts::arguments()("-h", "--help")) return ::tts::_::usage(argv[ 0 ]);
 
+  if(::tts::arguments()("--dry"))
+  {
+    for(auto& t: ::tts::_::suite())
+      ::tts::output().writeln(t.name);
+    return 0;
+  }
+
   ::tts::_::set_verbose(::tts::arguments()("-v", "--verbose"));
   ::tts::_::set_quiet(::tts::arguments()("-q", "--quiet"));
 

--- a/include/tts/engine/main.hpp
+++ b/include/tts/engine/main.hpp
@@ -120,7 +120,10 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
   if(::tts::arguments()("--dry"))
   {
     for(auto& t: ::tts::_::suite())
-      ::tts::output().writeln(t.name);
+    {
+      if(t.types.is_empty()) ::tts::output().writeln(t.name);
+      else ::tts::output().writeln("%s <%s>", t.name, t.types.data());
+    }
     return 0;
   }
 

--- a/include/tts/engine/main.hpp
+++ b/include/tts/engine/main.hpp
@@ -119,7 +119,7 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
 
   if(::tts::arguments()("--dry"))
   {
-    for(auto& t: ::tts::_::suite())
+    for(auto const& t: ::tts::_::suite())
     {
       if(t.types.is_empty()) ::tts::output().writeln(t.name);
       else ::tts::output().writeln("%s <%s>", t.name, t.types.data());

--- a/include/tts/engine/test.hpp
+++ b/include/tts/engine/test.hpp
@@ -9,6 +9,7 @@
 
 #include <tts/tools/buffer.hpp>
 #include <tts/tools/callable.hpp>
+#include <tts/tools/text.hpp>
 
 namespace tts::_
 {
@@ -25,6 +26,7 @@ namespace tts::_
 
     char const*        name;
     tts::_::callable   behaviour;
+    tts::text          types = {};
   };
 
   // Global tests suite

--- a/include/tts/engine/usage.hpp
+++ b/include/tts/engine/usage.hpp
@@ -18,6 +18,7 @@ Flags:
   -v, --verbose     Display tests results regardless of their status.
   -q, --quiet       Display only test failures percentage.
   --allow-empty     Do not fail when the test suite registered zero test.
+  --dry             Print registered test names without running them.
 
 Parameters:
   --precision=arg   Set the precision for displaying floating pint values

--- a/test/unit/tests/dry_flag.cpp
+++ b/test/unit/tests/dry_flag.cpp
@@ -1,0 +1,47 @@
+//==================================================================================================
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#define TTS_MAIN
+#define TTS_CUSTOM_DRIVER_FUNCTION dry_flag_main
+#include <tts/tts.hpp>
+#include <array>
+
+TTS_CASE("First dummy test for --dry")
+{
+  TTS_EXPECT(1 == 1);
+};
+
+TTS_CASE("Second dummy test for --dry")
+{
+  TTS_EXPECT(1 == 1);
+};
+
+int main(int argc, char const** argv)
+{
+  ::tts::initialize(argc, argv);
+
+  bool                       ok = true;
+
+  std::array<char const*, 2> dry_argv {argv[ 0 ], "--dry"};
+  ::tts::_::current_arguments           = ::tts::options {2, dry_argv.data()};
+
+  auto                test_count_before = ::tts::global_runtime.test_count;
+  tts::gathering_sink gs;
+  {
+    tts::scoped_sink scope(gs);
+    int              rc = dry_flag_main(argc, argv);
+    ok                  = ok && (rc == 0);
+  }
+
+  // --dry must not execute any test.
+  ok = ok && (::tts::global_runtime.test_count == test_count_before);
+
+  ok = ok && (strstr(gs.content().data(), "First dummy test for --dry") != nullptr);  // NOSONAR
+  ok = ok && (strstr(gs.content().data(), "Second dummy test for --dry") != nullptr); // NOSONAR
+
+  return ok ? 0 : 1;
+}

--- a/test/unit/tests/dry_flag.cpp
+++ b/test/unit/tests/dry_flag.cpp
@@ -20,6 +20,12 @@ TTS_CASE("Second dummy test for --dry")
   TTS_EXPECT(1 == 1);
 };
 
+TTS_CASE_TPL("Templated dummy test for --dry", std::int32_t, double)
+<typename T>(::tts::type<T>)
+{
+  TTS_EXPECT(1 == 1);
+};
+
 int main(int argc, char const** argv)
 {
   ::tts::initialize(argc, argv);
@@ -42,6 +48,11 @@ int main(int argc, char const** argv)
 
   ok = ok && (strstr(gs.content().data(), "First dummy test for --dry") != nullptr);  // NOSONAR
   ok = ok && (strstr(gs.content().data(), "Second dummy test for --dry") != nullptr); // NOSONAR
+
+  // TTS_CASE_TPL entries must list their types, without pinning down the exact spelling
+  // (e.g. int32_t vs int) since that's compiler/platform dependent.
+  ok =
+  ok && (strstr(gs.content().data(), "Templated dummy test for --dry <") != nullptr); // NOSONAR
 
   return ok ? 0 : 1;
 }


### PR DESCRIPTION
Adds `--dry`: prints each registered test's name and exits before any test executes - useful for CI to enumerate a suite ahead of the follow-up `--shard` flag (part 2/2, separate PR).

For `TTS_CASE_TPL`/`TTS_CASE_WITH`, the type list is also printed (`name <T1, T2, ...>`), built at registration time from the compile-time known type pack. `TTS_WHEN`/`TTS_AND_THEN` sub-scenarios can't be listed this way since they only exist as runtime control flow inside a test's body, which `--dry` never executes - documented in `doc/cli.hpp`, which also backfills the previously undocumented `--allow-empty` and `--capture=` flags.