### PR TITLE
Fix #167 (part 2/2) - Add --shard=i/n for CI test parallelization

### DIFF
--- a/doc/cli.hpp
+++ b/doc/cli.hpp
@@ -27,6 +27,21 @@
   `--dry`           | Print registered test names without running them. `./my_test --dry`
   `--allow-empty`   | Do not fail when the test suite registered zero test. `./my_test --allow-empty`
   `--capture=path`  | Capture this run's output and write it to `path` instead of stdout. `./my_test --capture=report.txt`
+  `--shard=i/n`     | Only run the tests in shard `i` of `n` (`0 <= i < n`). `./my_test --shard=1/3`
+
+  @note `--shard=i/n` partitions tests by registration index, round-robin (test at index `k`
+  belongs to shard `k % n`), not by contiguous blocks - this keeps shards balanced even when
+  slow tests cluster together in source order. A shard landing on zero tests (e.g. `n` larger
+  than the suite's size) is not treated as a build error: `--shard` implicitly behaves like
+  `--allow-empty` for that case. It composes with `--dry`, which then only lists the tests
+  that shard would actually run.
+
+  @note `--shard` is a no-op for binaries using a @ref TTS_CUSTOM_DRIVER_FUNCTION - it only
+  applies to the default driver. Those binaries typically assert a fixed, whole-suite fail/
+  invalid count via `tts::report(fails, invalids)` from outside the driver loop, and
+  round-robin partitioning has no way to know how many of that fixed total fall in a given
+  shard, so shard-filtering them could spuriously pass or fail. See #187 for a possible future
+  per-test expected-outcome mechanism that would lift this restriction.
 
   @note `--dry` only prints what's known without running any test: registered @ref TTS_CASE /
   @ref TTS_CASE_TPL / @ref TTS_CASE_WITH names, plus their types for the latter two. It cannot

--- a/include/tts/engine/environment.hpp
+++ b/include/tts/engine/environment.hpp
@@ -73,7 +73,10 @@ namespace tts::_
 
       out.writeln();
 
-      if(test_count == 0 && !::tts::arguments()("--allow-empty")) return 1;
+      // A shard landing on zero tests is an expected partition outcome, not a build/
+      // registration bug, so --shard implicitly behaves like --allow-empty here.
+      if(test_count == 0 && !::tts::arguments()("--allow-empty") && !::tts::arguments()("--shard"))
+        return 1;
 
       if(!fails && !invalids) return test_count == success_count ? 0 : 1;
       else return (failure_count == fails && invalid_count == invalids) ? 0 : 1;

--- a/include/tts/engine/main.hpp
+++ b/include/tts/engine/main.hpp
@@ -141,7 +141,8 @@ namespace tts::_
     ::tts::text raw = ::tts::arguments().value<::tts::text>("--shard");
     if(raw.is_empty()) return {};
 
-    unsigned int i = 0, n = 0;
+    unsigned int i = 0;
+    unsigned int n = 0;
     if(sscanf(raw.data(), "%u/%u", &i, &n) != 2 || n == 0 || i >= n)
     {
       ok = false;
@@ -179,11 +180,10 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
     std::size_t position = 0;
     for(auto const& t: ::tts::_::suite())
     {
-      if(shard.selects(position++))
-      {
-        if(t.types.is_empty()) ::tts::output().writeln(t.name);
-        else ::tts::output().writeln("%s <%s>", t.name, t.types.data());
-      }
+      if(!shard.selects(position++)) continue;
+
+      if(t.types.is_empty()) ::tts::output().writeln(t.name);
+      else ::tts::output().writeln("%s <%s>", t.name, t.types.data());
     }
     return 0;
   }

--- a/include/tts/engine/main.hpp
+++ b/include/tts/engine/main.hpp
@@ -108,6 +108,49 @@ namespace tts::_
 
     ::tts::output().writeln("  [@] %s : @@ FATAL @@ : %s", location, message);
   }
+
+  // Splits the suite in `total` round-robin shards (test at registration index k belongs to
+  // shard k % total), so a slow binary can be spread across parallel CI workers without
+  // splitting source files. See --shard in doc/cli.hpp.
+  struct shard_spec
+  {
+    bool         active = false;
+    unsigned int index  = 0;
+    unsigned int total  = 1;
+
+    bool         selects(std::size_t position) const
+    {
+      return !active || (position % total == index);
+    }
+
+    std::size_t count(std::size_t suite_size) const
+    {
+      if(!active) return suite_size;
+      if(suite_size <= index) return 0;
+      return (suite_size - index - 1) / total + 1;
+    }
+  };
+
+  // Parses --shard=i/n. `ok` is set to false if the flag is present but malformed or out of
+  // range (n == 0 or i >= n); the returned shard_spec is then meaningless and must be ignored.
+  TTS_DISABLE_WARNING_PUSH
+  TTS_DISABLE_WARNING_CRT_SECURE
+  inline shard_spec parse_shard(bool& ok)
+  {
+    ok              = true;
+    ::tts::text raw = ::tts::arguments().value<::tts::text>("--shard");
+    if(raw.is_empty()) return {};
+
+    unsigned int i = 0, n = 0;
+    if(sscanf(raw.data(), "%u/%u", &i, &n) != 2 || n == 0 || i >= n)
+    {
+      ok = false;
+      return {};
+    }
+
+    return {true, i, n};
+  }
+  TTS_DISABLE_WARNING_POP
 }
 
 TTS_DISABLE_WARNING_PUSH
@@ -117,12 +160,30 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
   ::tts::initialize(argc, argv);
   if(::tts::arguments()("-h", "--help")) return ::tts::_::usage(argv[ 0 ]);
 
+  bool shard_ok = true;
+  auto shard    = ::tts::_::parse_shard(shard_ok);
+  if(!shard_ok)
+  {
+    ::tts::output().writeln("Invalid --shard value, expected i/n with 0 <= i < n");
+    return 1;
+  }
+
+  // --shard only makes sense for the default "everything that ran must pass" driver: a custom
+  // driver's caller typically expects a fixed, whole-suite fail/invalid count from
+  // tts::report(fails, invalids), which round-robin partitioning has no way to redistribute
+  // correctly, so --shard is a no-op there instead of risking a spurious pass or failure.
+  if constexpr(!::tts::_::use_main) shard.active = false;
+
   if(::tts::arguments()("--dry"))
   {
+    std::size_t position = 0;
     for(auto const& t: ::tts::_::suite())
     {
-      if(t.types.is_empty()) ::tts::output().writeln(t.name);
-      else ::tts::output().writeln("%s <%s>", t.name, t.types.data());
+      if(shard.selects(position++))
+      {
+        if(t.types.is_empty()) ::tts::output().writeln(t.name);
+        else ::tts::output().writeln("%s <%s>", t.name, t.types.data());
+      }
     }
     return 0;
   }
@@ -146,17 +207,26 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
   ::tts::gathering_sink capture_sink;
   if(capture_file) ::tts::output().sink(capture_sink);
 
-  auto        nb_tests   = ::tts::_::suite().size();
+  auto        nb_tests   = shard.count(::tts::_::suite().size());
   std::size_t done_tests = 0;
   auto        seed       = ::tts::random_seed();
   ::tts::set_random_seed(static_cast<std::uint64_t>(seed));
   ::tts::output().writeln(
   "Random seed: %d (rerun with --seed=%d to reproduce this run)", seed, seed);
+  if(shard.active)
+    ::tts::output().writeln("Shard: %u/%u (%zu test%s selected)",
+                            shard.index,
+                            shard.total,
+                            nb_tests,
+                            nb_tests > 1 ? "s" : "");
 
   try
   {
+    std::size_t position = 0;
     for(auto& t: ::tts::_::suite())
     {
+      if(!shard.selects(position++)) continue;
+
       auto test_count                   = ::tts::global_runtime.test_count;
       auto failure_count                = ::tts::global_runtime.failure_count;
       ::tts::global_runtime.fail_status = false;

--- a/include/tts/engine/usage.hpp
+++ b/include/tts/engine/usage.hpp
@@ -24,6 +24,7 @@ Parameters:
   --precision=arg   Set the precision for displaying floating pint values
   --seed=arg        Set the PRNG seeds (default is time-based)
   --capture=path    Capture this run's output and write it to path instead of stdout
+  --shard=i/n       Only run the tests in shard i of n (0 <= i < n), for CI parallelization
 
 Range specifics Parameters:
   --block=arg       Set size of range checks samples (min. 32)

--- a/test/unit/tests/shard_flag.cpp
+++ b/test/unit/tests/shard_flag.cpp
@@ -17,7 +17,9 @@ TTS_CASE("shard_spec partitions round-robin and stays balanced")
   tts::_::shard_spec    s2 {true, 2, 3};
 
   constexpr std::size_t n  = 17;
-  std::size_t           c0 = 0, c1 = 0, c2 = 0;
+  std::size_t           c0 = 0;
+  std::size_t           c1 = 0;
+  std::size_t           c2 = 0;
 
   for(std::size_t k = 0; k < n; ++k)
   {
@@ -39,8 +41,9 @@ TTS_CASE("shard_spec partitions round-robin and stays balanced")
 
 namespace
 {
-  bool first_dummy_ran  = false;
-  bool second_dummy_ran = false;
+  // Intentionally mutable: set from within the test bodies below to prove they ran.
+  bool first_dummy_ran  = false; // NOSONAR
+  bool second_dummy_ran = false; // NOSONAR
 }
 
 TTS_CASE("First dummy test so shard_flag_main has something to (not) filter")

--- a/test/unit/tests/shard_flag.cpp
+++ b/test/unit/tests/shard_flag.cpp
@@ -1,0 +1,116 @@
+//==================================================================================================
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#define TTS_MAIN
+#define TTS_CUSTOM_DRIVER_FUNCTION shard_flag_main
+#include <tts/tts.hpp>
+#include <array>
+
+TTS_CASE("shard_spec partitions round-robin and stays balanced")
+{
+  tts::_::shard_spec    s0 {true, 0, 3};
+  tts::_::shard_spec    s1 {true, 1, 3};
+  tts::_::shard_spec    s2 {true, 2, 3};
+
+  constexpr std::size_t n  = 17;
+  std::size_t           c0 = 0, c1 = 0, c2 = 0;
+
+  for(std::size_t k = 0; k < n; ++k)
+  {
+    // Every index belongs to exactly one of the three shards.
+    TTS_EQUAL(static_cast<int>(s0.selects(k)) + static_cast<int>(s1.selects(k)) +
+              static_cast<int>(s2.selects(k)),
+              1);
+
+    if(s0.selects(k)) ++c0;
+    if(s1.selects(k)) ++c1;
+    if(s2.selects(k)) ++c2;
+  }
+
+  TTS_EQUAL(c0, s0.count(n));
+  TTS_EQUAL(c1, s1.count(n));
+  TTS_EQUAL(c2, s2.count(n));
+  TTS_EQUAL(c0 + c1 + c2, n);
+};
+
+namespace
+{
+  bool first_dummy_ran  = false;
+  bool second_dummy_ran = false;
+}
+
+TTS_CASE("First dummy test so shard_flag_main has something to (not) filter")
+{
+  first_dummy_ran = true;
+  TTS_EXPECT(1 == 1);
+};
+
+TTS_CASE("Second dummy test so shard_flag_main has something to (not) filter")
+{
+  second_dummy_ran = true;
+  TTS_EXPECT(1 == 1);
+};
+
+int main(int argc, char const** argv)
+{
+  ::tts::initialize(argc, argv);
+
+  bool ok = true;
+
+  // A shard landing on zero tests must not fail, same as --allow-empty (nothing has run yet
+  // at this point in a fresh process, so test_count is guaranteed to still be 0 here).
+  {
+    std::array<char const*, 2> empty_shard_argv {argv[ 0 ], "--shard=0/2"};
+    ::tts::_::current_arguments = ::tts::options {2, empty_shard_argv.data()};
+
+    ok                          = ok && (::tts::global_runtime.test_count == 0);
+    ok                          = ok && (::tts::report(0, 0) == 0);
+  }
+
+  // Valid --shard= is parsed correctly.
+  {
+    std::array<char const*, 2> valid_argv {argv[ 0 ], "--shard=1/4"};
+    ::tts::_::current_arguments   = ::tts::options {2, valid_argv.data()};
+
+    bool                 parse_ok = false;
+    ::tts::_::shard_spec spec     = ::tts::_::parse_shard(parse_ok);
+    ok = ok && parse_ok && spec.active && (spec.index == 1) && (spec.total == 4);
+  }
+
+  // Malformed or out-of-range --shard= values are rejected.
+  for(char const* bad: {"--shard=abc", "--shard=2/2", "--shard=1/0", "--shard=/3", "--shard=1/"})
+  {
+    std::array<char const*, 2> bad_argv {argv[ 0 ], bad};
+    ::tts::_::current_arguments = ::tts::options {2, bad_argv.data()};
+
+    bool parse_ok               = true;
+    ::tts::_::parse_shard(parse_ok);
+    ok = ok && !parse_ok;
+  }
+
+  // No --shard at all: parsing succeeds and yields an inactive shard.
+  {
+    std::array<char const*, 1> no_shard_argv {argv[ 0 ]};
+    ::tts::_::current_arguments   = ::tts::options {1, no_shard_argv.data()};
+
+    bool                 parse_ok = false;
+    ::tts::_::shard_spec spec     = ::tts::_::parse_shard(parse_ok);
+    ok                            = ok && parse_ok && !spec.active;
+  }
+
+  // --shard is a no-op for a custom driver: every registered test still runs, not just the
+  // round-robin subset --shard=0/2 would otherwise select.
+  {
+    std::array<char const*, 2> shard_argv {argv[ 0 ], "--shard=0/2"};
+    ::tts::_::current_arguments = ::tts::options {2, shard_argv.data()};
+
+    shard_flag_main(argc, argv);
+    ok = ok && first_dummy_ran && second_dummy_ran;
+  }
+
+  return ok ? 0 : 1;
+}


### PR DESCRIPTION
Round-robin partitioning (test at registration index `k` belongs to shard `k % n`), 0-based `i`, validated at parse time - fails fast on a malformed value or `i >= n`. Composes with `--dry` (lists only the tests that shard would run) and implicitly behaves like `--allow-empty` when a shard lands on zero tests, since that's an expected partition outcome rather than a build/registration bug.

`--shard` is a no-op for `TTS_CUSTOM_DRIVER_FUNCTION` binaries: several of those (`infos.cpp`, `failure.cpp`, most of the `typed_*`/`pass_fail`/`custom-display` doc snippets) assert a fixed, whole-suite fail/invalid count via `tts::report(fails, invalids)` from outside the driver loop, and round-robin partitioning has no way to know how many of that fixed total fall in a given shard - shard-filtering them could spuriously pass or fail. #187 tracks a possible future per-test expected-outcome mechanism that would lift this restriction.

Filed #186 separately for a generic env-var fallback across every `tts::arguments()`-driven option (needed to actually use `--shard` from our own `ctest`-based CI, since its command list is fixed at configure time) - out of scope here, this PR only ships the CLI flag.