### PR TITLE
Fix #186 - Environment-variable fallback for every CLI option

### DIFF
--- a/doc/cli.hpp
+++ b/doc/cli.hpp
@@ -6,6 +6,42 @@
 
   @tableofcontents
 
+  # Environment Variable Fallback
+
+  Every long-form option below (`--xxx` or `--xxx=value`) can also be set via a matching
+  `TTS_XXX` environment variable instead of a command line flag - derived by uppercasing the
+  flag name and replacing `-` with `_`. Short forms (`-v`, `-q`, ...) have no environment
+  variable equivalent. A CLI flag always takes precedence over its environment variable when
+  both are set.
+
+  This exists mainly for CI systems where the test command itself is fixed (e.g. `ctest`
+  invokes every registered binary through a command line set once at configure time) and
+  can't easily template a different flag value per parallel job, but can set a different
+  environment variable per job instead:
+
+  @code{sh}
+  TTS_SHARD=0/4 ./my_test   # same as ./my_test --shard=0/4
+  @endcode
+
+  Environment Variable | Equivalent Option
+  --------------------- | -----------------
+  `TTS_HELP`            | `--help` / `-h`
+  `TTS_HEX`             | `--hex` / `-x`
+  `TTS_SCIENTIFIC`      | `--scientific` / `-s`
+  `TTS_VERBOSE`         | `--verbose` / `-v`
+  `TTS_QUIET`           | `--quiet` / `-q`
+  `TTS_DRY`             | `--dry`
+  `TTS_ALLOW_EMPTY`     | `--allow-empty`
+  `TTS_CAPTURE`         | `--capture=path`
+  `TTS_SHARD`           | `--shard=i/n`
+  `TTS_PRECISION`       | `--precision=N`
+  `TTS_SEED`            | `--seed=N`
+  `TTS_BLOCK`           | `--block=N`
+  `TTS_LOOP`            | `--loop=N`
+  `TTS_ULPMAX`          | `--ulpmax=N`
+  `TTS_VALMIN`          | `--valmin=N`
+  `TTS_VALMAX`          | `--valmax=N`
+
   # Display Options
 
   The following options modify how the tests are run and the results displayed.

--- a/include/tts/tools/options.hpp
+++ b/include/tts/tools/options.hpp
@@ -18,6 +18,8 @@ namespace tts::_
   struct option
   {
     option() = default;
+
+    // Parses a raw CLI argument, e.g. "--capture=report.txt" or "--verbose".
     explicit option(char const* arg)
         : token(arg)
         , position(-1)
@@ -25,6 +27,17 @@ namespace tts::_
       assert(arg && "Token cannot be null");
       auto it  = strchr(arg, '=');
       position = it ? static_cast<int>(it - token) : static_cast<int>(strlen(token)); // NOSONAR
+    }
+
+    // Wraps an already-split name/value pair (e.g. a flag and the environment variable value
+    // standing in for it) - no '='-parsing needed, name and value are independent pointers.
+    option(char const* name, char const* value)
+        : token(name)
+        , position(static_cast<int>(strlen(name))) // NOSONAR
+        , env_value(value)
+    {
+      assert(name && "Name cannot be null");
+      assert(value && "Value cannot be null");
     }
 
     bool has_flag(char const* f) const
@@ -49,23 +62,24 @@ namespace tts::_
 
       if(is_valid())
       {
-        int n = 0;
+        char const* raw = env_value ? env_value : token + position + 1;
+        int         n   = 0;
         if constexpr(std::integral<T>)
         {
           decltype(sizeof(void*)) v;
-          n    = sscanf(token + position + 1, "%zu", &v);
+          n    = sscanf(raw, "%zu", &v);
           that = static_cast<T>(v);
         }
         else if constexpr(std::floating_point<T>)
         {
           double v;
-          n    = sscanf(token + position + 1, "%lf", &v);
+          n    = sscanf(raw, "%lf", &v);
           that = static_cast<T>(v);
         }
         else
         {
           n    = 1;
-          that = T {token + position + 1};
+          that = T {raw};
         }
 
         if(n != 1) that = def;
@@ -78,8 +92,9 @@ namespace tts::_
       return that;
     }
 
-    char const* token    = "";
-    int         position = -1;
+    char const* token     = "";
+    int         position  = -1;
+    char const* env_value = nullptr;
   };
 }
 

--- a/include/tts/tools/options.hpp
+++ b/include/tts/tools/options.hpp
@@ -96,6 +96,27 @@ namespace tts::_
     int         position  = -1;
     char const* env_value = nullptr;
   };
+
+  // Derives "TTS_<NAME>" from a long-form flag like "--shard" (-> "TTS_SHARD") or
+  // "--allow-empty" (-> "TTS_ALLOW_EMPTY"). Returns an empty text for short flags (single
+  // dash, e.g. "-v") since those don't map to a sensible environment variable name.
+  inline text env_var_name(char const* flag)
+  {
+    if(!flag || flag[ 0 ] != '-' || flag[ 1 ] != '-' || flag[ 2 ] == '\0') return text {};
+
+    char        buffer[ 64 ] = "TTS_";
+    std::size_t pos          = 4;
+    for(char const* p = flag + 2; *p && pos < sizeof(buffer) - 1; ++p)
+    {
+      char c = *p;
+      if(c == '-') c = '_';
+      else if(c >= 'a' && c <= 'z') c = static_cast<char>(c - 'a' + 'A');
+      buffer[ pos++ ] = c;
+    }
+    buffer[ pos ] = '\0';
+
+    return text {buffer};
+  }
 }
 
 namespace tts
@@ -192,6 +213,16 @@ namespace tts
         {
           if(o.has_flag(f)) return o;
         }
+      }
+
+      // No matching CLI flag: fall back to a TTS_<FLAG_NAME> environment variable, if set.
+      // CLI always takes precedence over the environment.
+      for(auto f: flags)
+      {
+        auto name = _::env_var_name(f);
+        if(name.is_empty()) continue;
+
+        if(char const* value = getenv(name.data())) return _::option {f, value};
       }
 
       return _::option {};

--- a/include/tts/tools/options.hpp
+++ b/include/tts/tools/options.hpp
@@ -104,10 +104,12 @@ namespace tts::_
   {
     if(!flag || flag[ 0 ] != '-' || flag[ 1 ] != '-' || flag[ 2 ] == '\0') return text {};
 
-    char        buffer[ 64 ] = "TTS_";
-    std::size_t pos          = 4;
-    for(char const* p = flag + 2; *p && pos < sizeof(buffer) - 1; ++p)
+    char buffer[ 64 ] = "TTS_"; // NOSONAR - avoids std::string, this project avoids that header
+    std::size_t pos   = 4;
+    for(char const* p = flag + 2; *p; ++p)
     {
+      if(pos >= sizeof(buffer) - 1) break;
+
       char c = *p;
       if(c == '-') c = '_';
       else if(c >= 'a' && c <= 'z') c = static_cast<char>(c - 'a' + 'A');

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,6 +14,7 @@ copa_make_single_unit ( INTERFACE     tts_test
                                       unit/infrastructure/buffer.cpp
                                       unit/infrastructure/callable.cpp
                                       unit/infrastructure/display.cpp
+                                      unit/infrastructure/options.cpp
                                       unit/infrastructure/output.cpp
                                       unit/infrastructure/main.cpp
                         ROOT          ${root}

--- a/test/unit/infrastructure/options.cpp
+++ b/test/unit/infrastructure/options.cpp
@@ -1,0 +1,49 @@
+//==================================================================================================
+/**
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: MIT
+**/
+//==================================================================================================
+#include <tts/tts.hpp>
+
+TTS_CASE("Check default constructed option is invalid")
+{
+  tts::_::option o;
+  TTS_EXPECT_NOT(o.is_valid());
+};
+
+TTS_CASE("Check option parses a bare CLI flag (no value)")
+{
+  tts::_::option o {"--verbose"};
+  TTS_EXPECT(o.is_valid());
+  TTS_EXPECT(o.has_flag("--verbose"));
+  TTS_EXPECT_NOT(o.has_flag("--quiet"));
+};
+
+TTS_CASE("Check option parses a CLI flag with a value")
+{
+  tts::_::option o {"--seed=42"};
+  TTS_EXPECT(o.is_valid());
+  TTS_EXPECT(o.has_flag("--seed"));
+  TTS_EQUAL(o.get<int>(), 42);
+  TTS_EQUAL(o.get<double>(), 42.);
+};
+
+TTS_CASE("Check option built from a separate name/value pair (env var style)")
+{
+  tts::_::option o {"--shard", "1/4"};
+  TTS_EXPECT(o.is_valid());
+  TTS_EXPECT(o.has_flag("--shard"));
+  TTS_EXPECT_NOT(o.has_flag("--seed"));
+  TTS_EQUAL(o.get<tts::text>(), "1/4");
+};
+
+TTS_CASE("Check option::get from a separate name/value pair parses integrals and floats")
+{
+  tts::_::option i {"--block", "4096"};
+  TTS_EQUAL(i.get<int>(), 4096);
+
+  tts::_::option f {"--ulpmax", "2.5"};
+  TTS_EQUAL(f.get<double>(), 2.5);
+};

--- a/test/unit/infrastructure/options.cpp
+++ b/test/unit/infrastructure/options.cpp
@@ -6,6 +6,19 @@
 **/
 //==================================================================================================
 #include <tts/tts.hpp>
+#include <array>
+
+TTS_CASE("Check env_var_name derives TTS_<NAME> from a long-form flag")
+{
+  TTS_EQUAL(tts::_::env_var_name("--shard"), "TTS_SHARD");
+  TTS_EQUAL(tts::_::env_var_name("--allow-empty"), "TTS_ALLOW_EMPTY");
+};
+
+TTS_CASE("Check env_var_name rejects short flags and null")
+{
+  TTS_EXPECT(tts::_::env_var_name("-v").is_empty());
+  TTS_EXPECT(tts::_::env_var_name(nullptr).is_empty());
+};
 
 TTS_CASE("Check default constructed option is invalid")
 {
@@ -47,3 +60,39 @@ TTS_CASE("Check option::get from a separate name/value pair parses integrals and
   tts::_::option f {"--ulpmax", "2.5"};
   TTS_EQUAL(f.get<double>(), 2.5);
 };
+
+TTS_DISABLE_WARNING_PUSH
+TTS_DISABLE_WARNING_CRT_SECURE
+
+TTS_CASE("Check options falls back to a TTS_<FLAG> environment variable when no CLI flag matches")
+{
+  putenv(const_cast<char*>("TTS_QUX_TEST_FLAG=1")); // NOSONAR
+
+  std::array<char const*, 1> argv {"prog"};
+  tts::options               opts {1, argv.data()};
+
+  TTS_EXPECT(opts("--qux-test-flag"));
+  TTS_EXPECT_NOT(opts("--some-other-flag"));
+};
+
+TTS_CASE("Check a CLI flag takes precedence over its environment variable")
+{
+  putenv(const_cast<char*>("TTS_ANOTHER_TEST_FLAG=fromenv")); // NOSONAR
+
+  std::array<char const*, 2> argv {"prog", "--another-test-flag=fromcli"};
+  tts::options               opts {2, argv.data()};
+
+  TTS_EQUAL(opts.value<tts::text>("--another-test-flag"), "fromcli");
+};
+
+TTS_CASE("Check a value-taking option reads its environment variable")
+{
+  putenv(const_cast<char*>("TTS_YET_ANOTHER_TEST_FLAG=7")); // NOSONAR
+
+  std::array<char const*, 1> argv {"prog"};
+  tts::options               opts {1, argv.data()};
+
+  TTS_EQUAL(opts.value<int>("--yet-another-test-flag"), 7);
+};
+
+TTS_DISABLE_WARNING_POP

--- a/test/unit/infrastructure/options.cpp
+++ b/test/unit/infrastructure/options.cpp
@@ -64,6 +64,12 @@ TTS_CASE("Check option::get from a separate name/value pair parses integrals and
 TTS_DISABLE_WARNING_PUSH
 TTS_DISABLE_WARNING_CRT_SECURE
 
+// putenv() doesn't copy its argument, it stores the pointer directly in the environment -
+// passing it a pointer to an automatic (stack) variable is undefined behavior once that
+// variable goes out of scope (CERT POS34-C). Every call below is safe because it's given a
+// string literal, which has static storage duration for the whole program - never copy this
+// pattern with a dynamically-built buffer without also giving it static/longer storage.
+
 TTS_CASE("Check options falls back to a TTS_<FLAG> environment variable when no CLI flag matches")
 {
   putenv(const_cast<char*>("TTS_QUX_TEST_FLAG=1")); // NOSONAR


### PR DESCRIPTION
`tts::options::find()` now checks a `TTS_<FLAG_NAME>` environment variable (uppercased, `-` replaced with `_`) when no CLI argument matches, with CLI always taking precedence. Every existing option gets this for free since they all funnel through `find()`: `--dry`, `--shard`, `--capture`, `--verbose`, `--seed`, etc.

Split into two steps: `tts::_::option` first gains a name/value constructor for an already-split pair (no behavior change, verified before touching anything else), then `find()` is wired to use it for the environment fallback - no string synthesis needed, since both pointers (a `flags[]` literal and `getenv()`'s return) already outlive the call, avoiding a `thread_local` buffer.

Documented with an exhaustive variable-to-option table in `doc/cli.hpp`. This was the actual blocker for using `--shard` (#167) from our own `ctest`-based CI, since its test command list is fixed at configure time and can't easily template a different flag per parallel job - but can set a different environment variable per job.