### PR TITLE
Add structured per-test output_sink events

### DIFF
--- a/include/tts/engine/main.hpp
+++ b/include/tts/engine/main.hpp
@@ -100,6 +100,8 @@ namespace tts::_
     {
       ::tts::output().writeln("  [X] %s : ** FAILURE ** : %s", location, message);
     }
+
+    ::tts::output().assertion_failed(::tts::text {location}, ::tts::text {message}, false);
   }
 
   void report_fatal(char const* location, char const* message, ::tts::text const& type)
@@ -107,6 +109,8 @@ namespace tts::_
     report_type_hint(type);
 
     ::tts::output().writeln("  [@] %s : @@ FATAL @@ : %s", location, message);
+
+    ::tts::output().assertion_failed(::tts::text {location}, ::tts::text {message}, true);
   }
 
   // Splits the suite in `total` round-robin shards (test at registration index k belongs to
@@ -231,22 +235,29 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
       auto failure_count                = ::tts::global_runtime.failure_count;
       ::tts::global_runtime.fail_status = false;
 
+      ::tts::output().test_started(::tts::text {t.name});
+
       if(!::tts::is_quiet()) ::tts::output().writeln("TEST: '%s'", t.name);
       ::tts::output().flush();
       t();
       done_tests++;
 
-      if(test_count == ::tts::global_runtime.test_count)
+      bool invalid = (test_count == ::tts::global_runtime.test_count);
+      bool passed  = !invalid && (failure_count == ::tts::global_runtime.failure_count);
+
+      if(invalid)
       {
         ::tts::global_runtime.invalid();
         if(!::tts::is_quiet()) ::tts::output().writeln("  [!!]: EMPTY TEST CASE");
         ::tts::output().flush();
       }
-      else if(failure_count == ::tts::global_runtime.failure_count)
+      else if(passed)
       {
         if(!::tts::is_quiet()) ::tts::output().writeln("TEST: '%s' - [PASSED]", t.name);
         ::tts::output().flush();
       }
+
+      ::tts::output().test_finished(::tts::text {t.name}, passed, invalid);
     }
   }
   catch(::tts::_::fatal_signal&)

--- a/include/tts/tools/output.hpp
+++ b/include/tts/tools/output.hpp
@@ -101,6 +101,33 @@ namespace tts
       // Intentionally empty: most sinks (e.g. gathering_sink) have nothing meaningful to flush.
     }
 
+    /// Called when a @ref TTS_CASE / @ref TTS_CASE_TPL / @ref TTS_CASE_WITH is about to run.
+    /// No-op by default - opt-in for sinks that want structured per-test events instead of (or
+    /// in addition to) parsing the formatted text stream.
+    virtual void test_started([[maybe_unused]] text const& name)
+    {
+      // Intentionally empty: most sinks only care about the formatted text stream.
+    }
+
+    /// Called once per failing/fatal assertion, right before the corresponding text is written.
+    /// No-op by default. Not called for passing assertions - test_finished()'s `passed` already
+    /// covers that case, and most consumers of this hook don't want one event per assertion.
+    virtual void assertion_failed([[maybe_unused]] text const& location,
+                                  [[maybe_unused]] text const& message,
+                                  [[maybe_unused]] bool        fatal)
+    {
+      // Intentionally empty: most sinks only care about the formatted text stream.
+    }
+
+    /// Called once a @ref TTS_CASE / @ref TTS_CASE_TPL / @ref TTS_CASE_WITH has finished
+    /// running, with its outcome. No-op by default.
+    virtual void test_finished([[maybe_unused]] text const& name,
+                               [[maybe_unused]] bool        passed,
+                               [[maybe_unused]] bool        invalid)
+    {
+      // Intentionally empty: most sinks only care about the formatted text stream.
+    }
+
     virtual ~output_sink() = default;
   };
 
@@ -251,6 +278,24 @@ namespace tts
     void flush()
     {
       sink_->flush();
+    }
+
+    /// Notifies the current output_sink that a test is about to run.
+    void test_started(text const& name)
+    {
+      sink_->test_started(name);
+    }
+
+    /// Notifies the current output_sink that an assertion failed.
+    void assertion_failed(text const& location, text const& message, bool fatal)
+    {
+      sink_->assertion_failed(location, message, fatal);
+    }
+
+    /// Notifies the current output_sink that a test has finished running.
+    void test_finished(text const& name, bool passed, bool invalid)
+    {
+      sink_->test_finished(name, passed, invalid);
     }
 
     /// Installs s as the output_sink every subsequent write goes to.

--- a/test/unit/tests/structured_sink.cpp
+++ b/test/unit/tests/structured_sink.cpp
@@ -20,7 +20,9 @@ TTS_CASE("Failing case for structured hooks")
 };
 
 TTS_CASE("Invalid case for structured hooks")
-{};
+{
+// Expect to be invalid because of missing assertion
+};
 
 namespace
 {

--- a/test/unit/tests/structured_sink.cpp
+++ b/test/unit/tests/structured_sink.cpp
@@ -1,0 +1,95 @@
+//==================================================================================================
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#define TTS_MAIN
+#define TTS_CUSTOM_DRIVER_FUNCTION structured_sink_main
+#include <tts/tts.hpp>
+
+TTS_CASE("Passing case for structured hooks")
+{
+  TTS_EXPECT(1 == 1);
+};
+
+TTS_CASE("Failing case for structured hooks")
+{
+  TTS_EXPECT(1 == 2);
+};
+
+TTS_CASE("Invalid case for structured hooks")
+{};
+
+namespace
+{
+  // Records every structured hook call as one tagged line per event, so the test below can
+  // check for exact, unambiguous lines instead of loose substring matches.
+  struct recording_sink : tts::output_sink
+  {
+    void write(tts::text const&) override
+    {
+      // Unused: this test only exercises the structured hooks, not the text stream.
+    }
+
+    void test_started(tts::text const& name) override
+    {
+      log += tts::text {"STARTED name=%s\n", name.data()};
+    }
+
+    void assertion_failed(tts::text const& location, tts::text const& message, bool fatal) override
+    {
+      log += tts::text {"FAILED fatal=%d message=%s\n", fatal ? 1 : 0, message.data()};
+      (void)location;
+    }
+
+    void test_finished(tts::text const& name, bool passed, bool invalid) override
+    {
+      log += tts::text {
+      "FINISHED name=%s passed=%d invalid=%d\n", name.data(), passed ? 1 : 0, invalid ? 1 : 0};
+    }
+
+    tts::text log;
+  };
+}
+
+int main(int argc, char const** argv)
+{
+  ::tts::initialize(argc, argv);
+
+  recording_sink sink;
+  {
+    tts::scoped_sink scope(sink);
+    structured_sink_main(argc, argv);
+  }
+
+  bool        ok  = true;
+  char const* log = sink.log.data();
+
+  ok =
+  ok && (strstr(log, "STARTED name=Passing case for structured hooks\n") != nullptr); // NOSONAR
+  ok =
+  ok &&
+  (strstr(log, "FINISHED name=Passing case for structured hooks passed=1 invalid=0\n") // NOSONAR
+   != nullptr);
+
+  ok =
+  ok && (strstr(log, "STARTED name=Failing case for structured hooks\n") != nullptr); // NOSONAR
+  ok =
+  ok && (strstr(log, "FAILED fatal=0 message=Expression: 1 == 2 evaluates to false.\n") // NOSONAR
+         != nullptr);
+  ok =
+  ok &&
+  (strstr(log, "FINISHED name=Failing case for structured hooks passed=0 invalid=0\n") // NOSONAR
+   != nullptr);
+
+  ok =
+  ok && (strstr(log, "STARTED name=Invalid case for structured hooks\n") != nullptr); // NOSONAR
+  ok =
+  ok &&
+  (strstr(log, "FINISHED name=Invalid case for structured hooks passed=0 invalid=1\n") // NOSONAR
+   != nullptr);
+
+  return ok ? 0 : 1;
+}


### PR DESCRIPTION
Extends tts::output_sink/output_handler with test_started, assertion_failed and test_finished hooks, mirroring the existing flush() pattern (opt-in, no-op by default). Wired into the driver loop and report_fail/report_fatal in main.hpp, so a sink can react to structured test outcomes instead of parsing the formatted text stream.

This is prep work for #164: the built-in sinks (tap in particular) can now consume these events directly instead of re-parsing text.