### PR TITLE
Issue #164 (1/3) - Ship colorized/TAP/diagnostics output_sinks

### DIFF
--- a/doc/layout.xml
+++ b/doc/layout.xml
@@ -7,6 +7,7 @@
       <tab type="user" url="@ref setup"   title="Setup"/>
       <tab type="user" url="@ref tts101"  title="Getting Started"/>
       <tab type="user" url="@ref cli"     title="Command Line Interface"/>
+      <tab type="user" url="@ref output-sinks" title="Built-in Output Sinks"/>
       <tab type="usergroup" visible="yes" title="Customizing TTS">
         <tab type="user" url="@ref customize"               title="General Behaviour"/>
         <tab type="user" url="@ref tools-generators-custom" title="Generators"/>

--- a/doc/sinks.hpp
+++ b/doc/sinks.hpp
@@ -15,10 +15,11 @@
   needed.
 
   All three draw from @ref tts::output_sink's structured hooks (`test_started()`,
-  `assertion_failed()`, `test_finished()`, `suite_finished()`, `suite_aborted()`) rather than by
-  parsing the text `tts::stdout_sink` prints, so they stay correct regardless of `-v`/`-q`. None
-  of them currently reflect @ref TTS_CASE_TPL's per-type breakdown or @ref TTS_WHEN /
-  @ref TTS_AND_THEN sub-scenarios, since those don't have their own hook.
+  `assertion_failed()`, `test_finished()`, `suite_finished()`, `suite_metric()`,
+  `suite_aborted()`) rather than by parsing the text `tts::stdout_sink` prints, so they stay
+  correct regardless of `-v`/`-q`. None of them currently reflect @ref TTS_CASE_TPL's per-type
+  breakdown or @ref TTS_WHEN / @ref TTS_AND_THEN sub-scenarios, since those don't have their own
+  hook.
 
   Sink                       | Purpose
   -------------------------- | -----------------------------------------------------------------
@@ -29,13 +30,14 @@
   # tts::colorized_sink
 
   Wraps a target sink (`tts::output_handler::default_sink()` by default) and colors a pass
-  confirmation (green), a failure/fatal/abort (red), an invalid test (yellow), or the final
-  `Results: ...` summary and the separator line right above it (green if everything passed, red
-  otherwise) - forwarding everything else unchanged. A color stays active across consecutive
-  lines until the next hook changes it, which is why the separator picks up the same color as the
-  `Results: ...` line that follows it. Opt-in: not every terminal or CI log renders ANSI escapes
-  usefully, and on Windows it additionally depends on the host console having Virtual Terminal
-  Processing enabled (most modern terminals already do).
+  confirmation (green), a failure/fatal/abort (red), an invalid test (yellow) - forwarding
+  everything else unchanged. The separator and the `Results: ...` prefix are bold and color-
+  neutral; only the `- N/M (P%) <label>` segment for each outcome category (success, failure,
+  invalid) is colored, in bold green/red/yellow respectively - so a run with both failures and
+  invalids shows each count in its own color rather than the whole line in one. A color stays
+  active across consecutive lines/segments until the next hook changes it. Opt-in: not every
+  terminal or CI log renders ANSI escapes usefully, and on Windows it additionally depends on the
+  host console having Virtual Terminal Processing enabled (most modern terminals already do).
 
   @code{cpp}
   tts::colorized_sink colorized;
@@ -45,8 +47,10 @@
   @endcode
 
   A failing run then looks like the usual TTS output, except `[PASSED]` lines are wrapped in
-  `\033[32m...\033[0m` (green), failure/fatal lines in `\033[31m...\033[0m` (red), and so on -
-  exactly what a terminal needs to render them in color.
+  `\033[32m...\033[0m` (green), failure/fatal lines in `\033[31m...\033[0m` (red), the `Results:`
+  line and separator in `\033[1m...\033[0m` (bold), and each of its outcome segments in
+  `\033[1;32m`/`\033[1;31m`/`\033[1;33m` (bold green/red/yellow) - exactly what a terminal needs
+  to render them in color.
 
   # tts::tap_sink
 

--- a/doc/sinks.hpp
+++ b/doc/sinks.hpp
@@ -1,0 +1,102 @@
+#error DO NOT INCLUDE - DOCUMENTATION PURPOSE ONLY
+
+//==================================================================================================
+/**
+  @page  output-sinks Built-in Output Sinks
+
+  @tableofcontents
+
+  # Overview
+
+  TTS has an extensible @ref tts::output_sink customization point (see @ref tools-config and the
+  `tts::gathering_sink` example) - everything a test suite prints goes through whichever sink is
+  currently installed. Beyond writing your own, TTS ships a small set of ready-to-use sinks under
+  `include/tts/sinks/`, already available through `#include <tts/tts.hpp>` with no extra include
+  needed.
+
+  Every one of them is derived from the same human-readable text `tts::stdout_sink` already
+  prints - there is no structured per-test event to draw from (name, status, timing, ...) yet -
+  so they recognize TTS's own wording ("TEST: 'name'", "[PASSED]", "** FAILURE **", ...) rather
+  than a stable machine format. In particular none of them currently reflect
+  @ref TTS_CASE_TPL's per-type breakdown or @ref TTS_WHEN / @ref TTS_AND_THEN sub-scenarios.
+
+  Sink                       | Purpose
+  -------------------------- | -----------------------------------------------------------------
+  `tts::colorized_sink`      | Wraps another sink, coloring pass/fail/fatal lines with ANSI escapes.
+  `tts::tap_sink`            | Gathers the run, then renders it as TAP (Test Anything Protocol).
+  `tts::diagnostics_sink`    | Rewrites failure/fatal lines as compiler-style diagnostics.
+
+  # tts::colorized_sink
+
+  Wraps a target sink (`tts::output_handler::default_sink()` by default) and colors messages that
+  look like a pass confirmation (green), a failure/fatal/abort (red), an invalid test (yellow), or
+  the final `Results: ...` summary (green if everything passed, red otherwise) - forwarding
+  everything else unchanged. Opt-in: not every terminal or CI log renders ANSI escapes usefully,
+  and on Windows it additionally depends on the host console having Virtual Terminal Processing
+  enabled (most modern terminals already do).
+
+  @code{cpp}
+  tts::colorized_sink colorized;
+  tts::output().sink(colorized);
+
+  // ... run the test suite ...
+  @endcode
+
+  A failing run then looks like the usual TTS output, except `[PASSED]` lines are wrapped in
+  `\033[32m...\033[0m` (green), failure/fatal lines in `\033[31m...\033[0m` (red), and so on -
+  exactly what a terminal needs to render them in color.
+
+  # tts::tap_sink
+
+  Accumulates the run's output like `tts::gathering_sink`, then `dump()` reconstructs one
+  `ok N - name` / `not ok N - name` line per @ref TTS_CASE, followed by a trailing `1..N` plan
+  line.
+
+  @code{cpp}
+  tts::tap_sink tap;
+  tts::output().sink(tap);
+
+  // ... run the test suite ...
+
+  tap.dump(); // stream the TAP-formatted report to stdout
+  @endcode
+
+  Given a suite with one passing and one failing case, `tap.dump()` prints:
+
+  @code{sh}
+  1..2
+  ok 1 - Check that expectation can be met
+  not ok 2 - Check that expectation fails
+  @endcode
+
+  # tts::diagnostics_sink
+
+  Wraps a target sink and rewrites lines that look like a @ref TTS_CASE failure or fatal error -
+  which already embed a `[file:line]` location - into `file:line: error: message` /
+  `file:line: fatal error: message`, so editors/IDEs with a GCC/Clang-style problem matcher
+  (VSCode's `$gcc`, vim's quickfix, ...) can jump straight to the failing assertion. Every other
+  message passes through unchanged.
+
+  @code{cpp}
+  tts::diagnostics_sink diagnostics;
+  tts::output().sink(diagnostics);
+
+  // ... run the test suite ...
+  @endcode
+
+  A failure that would normally print as:
+
+  @code{sh}
+    [X] [expect.cpp:15] : ** FAILURE ** : Expression: 1 == 2 evaluates to false.
+  @endcode
+
+  instead prints as:
+
+  @code{sh}
+  expect.cpp:15: error: Expression: 1 == 2 evaluates to false.
+  @endcode
+
+  @see tts::output_sink
+  @see tts::output_handler
+**/
+//==================================================================================================

--- a/doc/sinks.hpp
+++ b/doc/sinks.hpp
@@ -14,13 +14,11 @@
   `include/tts/sinks/`, already available through `#include <tts/tts.hpp>` with no extra include
   needed.
 
-  `tts::colorized_sink` works directly on the human-readable text `tts::stdout_sink` already
-  prints, recognizing TTS's own wording ("[PASSED]", "** FAILURE **", ...). `tts::tap_sink` and
-  `tts::diagnostics_sink` instead draw from @ref tts::output_sink's structured `test_finished()` /
-  `assertion_failed()` hooks, so they stay correct regardless of `-v`/`-q`. None of them currently
-  reflect @ref TTS_CASE_TPL's per-type breakdown or @ref TTS_WHEN / @ref TTS_AND_THEN
-  sub-scenarios, since those don't have their own hook or a distinct line of their own to key off
-  of.
+  All three draw from @ref tts::output_sink's structured hooks (`test_started()`,
+  `assertion_failed()`, `test_finished()`, `suite_finished()`, `suite_aborted()`) rather than by
+  parsing the text `tts::stdout_sink` prints, so they stay correct regardless of `-v`/`-q`. None
+  of them currently reflect @ref TTS_CASE_TPL's per-type breakdown or @ref TTS_WHEN /
+  @ref TTS_AND_THEN sub-scenarios, since those don't have their own hook.
 
   Sink                       | Purpose
   -------------------------- | -----------------------------------------------------------------
@@ -30,12 +28,14 @@
 
   # tts::colorized_sink
 
-  Wraps a target sink (`tts::output_handler::default_sink()` by default) and colors messages that
-  look like a pass confirmation (green), a failure/fatal/abort (red), an invalid test (yellow), or
-  the final `Results: ...` summary (green if everything passed, red otherwise) - forwarding
-  everything else unchanged. Opt-in: not every terminal or CI log renders ANSI escapes usefully,
-  and on Windows it additionally depends on the host console having Virtual Terminal Processing
-  enabled (most modern terminals already do).
+  Wraps a target sink (`tts::output_handler::default_sink()` by default) and colors a pass
+  confirmation (green), a failure/fatal/abort (red), an invalid test (yellow), or the final
+  `Results: ...` summary and the separator line right above it (green if everything passed, red
+  otherwise) - forwarding everything else unchanged. A color stays active across consecutive
+  lines until the next hook changes it, which is why the separator picks up the same color as the
+  `Results: ...` line that follows it. Opt-in: not every terminal or CI log renders ANSI escapes
+  usefully, and on Windows it additionally depends on the host console having Virtual Terminal
+  Processing enabled (most modern terminals already do).
 
   @code{cpp}
   tts::colorized_sink colorized;
@@ -75,8 +75,8 @@
   Wraps a target sink, forwarding every message unchanged, and additionally prints one
   `file:line: error: message` / `file:line: fatal error: message` line per failing/fatal
   assertion, so editors/IDEs with a GCC/Clang-style problem matcher (VSCode's `$gcc`, vim's
-  quickfix, ...) can jump straight to it. Since it comes from the same structured hook
-  `tts::tap_sink` uses, it still fires under `-q`, when the raw failure line it complements is
+  quickfix, ...) can jump straight to it. `assertion_failed()` fires before its corresponding
+  text, so the diagnostic line prints first; it still fires under `-q`, when that raw line is
   itself suppressed.
 
   @code{cpp}
@@ -86,11 +86,11 @@
   // ... run the test suite ...
   @endcode
 
-  A failing @ref TTS_CASE then prints its usual line, immediately followed by the diagnostic one:
+  A failing @ref TTS_CASE then prints the diagnostic line, immediately followed by its usual one:
 
   @code{sh}
-    [X] [expect.cpp:15] : ** FAILURE ** : Expression: 1 == 2 evaluates to false.
   expect.cpp:15: error: Expression: 1 == 2 evaluates to false.
+    [X] [expect.cpp:15] : ** FAILURE ** : Expression: 1 == 2 evaluates to false.
   @endcode
 
   @see tts::output_sink

--- a/doc/sinks.hpp
+++ b/doc/sinks.hpp
@@ -14,11 +14,12 @@
   `include/tts/sinks/`, already available through `#include <tts/tts.hpp>` with no extra include
   needed.
 
-  Every one of them is derived from the same human-readable text `tts::stdout_sink` already
-  prints - there is no structured per-test event to draw from (name, status, timing, ...) yet -
-  so they recognize TTS's own wording ("TEST: 'name'", "[PASSED]", "** FAILURE **", ...) rather
-  than a stable machine format. In particular none of them currently reflect
-  @ref TTS_CASE_TPL's per-type breakdown or @ref TTS_WHEN / @ref TTS_AND_THEN sub-scenarios.
+  `tts::colorized_sink` and `tts::diagnostics_sink` work directly on the human-readable text
+  `tts::stdout_sink` already prints, recognizing TTS's own wording ("[PASSED]", "** FAILURE **",
+  ...). `tts::tap_sink` instead draws from @ref output_sink's structured `test_finished()` hook,
+  so it stays correct regardless of `-v`/`-q`. None of them currently reflect
+  @ref TTS_CASE_TPL's per-type breakdown or @ref TTS_WHEN / @ref TTS_AND_THEN sub-scenarios, since
+  those don't have their own hook or a distinct line of their own to key off of.
 
   Sink                       | Purpose
   -------------------------- | -----------------------------------------------------------------
@@ -48,9 +49,8 @@
 
   # tts::tap_sink
 
-  Accumulates the run's output like `tts::gathering_sink`, then `dump()` reconstructs one
-  `ok N - name` / `not ok N - name` line per @ref TTS_CASE, followed by a trailing `1..N` plan
-  line.
+  Listens to `test_finished()` and accumulates one `ok N - name` / `not ok N - name` line per
+  @ref TTS_CASE, then `dump()` streams them out preceded by a leading `1..N` plan line.
 
   @code{cpp}
   tts::tap_sink tap;

--- a/doc/sinks.hpp
+++ b/doc/sinks.hpp
@@ -14,18 +14,19 @@
   `include/tts/sinks/`, already available through `#include <tts/tts.hpp>` with no extra include
   needed.
 
-  `tts::colorized_sink` and `tts::diagnostics_sink` work directly on the human-readable text
-  `tts::stdout_sink` already prints, recognizing TTS's own wording ("[PASSED]", "** FAILURE **",
-  ...). `tts::tap_sink` instead draws from @ref output_sink's structured `test_finished()` hook,
-  so it stays correct regardless of `-v`/`-q`. None of them currently reflect
-  @ref TTS_CASE_TPL's per-type breakdown or @ref TTS_WHEN / @ref TTS_AND_THEN sub-scenarios, since
-  those don't have their own hook or a distinct line of their own to key off of.
+  `tts::colorized_sink` works directly on the human-readable text `tts::stdout_sink` already
+  prints, recognizing TTS's own wording ("[PASSED]", "** FAILURE **", ...). `tts::tap_sink` and
+  `tts::diagnostics_sink` instead draw from @ref tts::output_sink's structured `test_finished()` /
+  `assertion_failed()` hooks, so they stay correct regardless of `-v`/`-q`. None of them currently
+  reflect @ref TTS_CASE_TPL's per-type breakdown or @ref TTS_WHEN / @ref TTS_AND_THEN
+  sub-scenarios, since those don't have their own hook or a distinct line of their own to key off
+  of.
 
   Sink                       | Purpose
   -------------------------- | -----------------------------------------------------------------
   `tts::colorized_sink`      | Wraps another sink, coloring pass/fail/fatal lines with ANSI escapes.
   `tts::tap_sink`            | Gathers the run, then renders it as TAP (Test Anything Protocol).
-  `tts::diagnostics_sink`    | Rewrites failure/fatal lines as compiler-style diagnostics.
+  `tts::diagnostics_sink`    | Adds compiler-style diagnostics for failure/fatal assertions.
 
   # tts::colorized_sink
 
@@ -71,11 +72,12 @@
 
   # tts::diagnostics_sink
 
-  Wraps a target sink and rewrites lines that look like a @ref TTS_CASE failure or fatal error -
-  which already embed a `[file:line]` location - into `file:line: error: message` /
-  `file:line: fatal error: message`, so editors/IDEs with a GCC/Clang-style problem matcher
-  (VSCode's `$gcc`, vim's quickfix, ...) can jump straight to the failing assertion. Every other
-  message passes through unchanged.
+  Wraps a target sink, forwarding every message unchanged, and additionally prints one
+  `file:line: error: message` / `file:line: fatal error: message` line per failing/fatal
+  assertion, so editors/IDEs with a GCC/Clang-style problem matcher (VSCode's `$gcc`, vim's
+  quickfix, ...) can jump straight to it. Since it comes from the same structured hook
+  `tts::tap_sink` uses, it still fires under `-q`, when the raw failure line it complements is
+  itself suppressed.
 
   @code{cpp}
   tts::diagnostics_sink diagnostics;
@@ -84,15 +86,10 @@
   // ... run the test suite ...
   @endcode
 
-  A failure that would normally print as:
+  A failing @ref TTS_CASE then prints its usual line, immediately followed by the diagnostic one:
 
   @code{sh}
     [X] [expect.cpp:15] : ** FAILURE ** : Expression: 1 == 2 evaluates to false.
-  @endcode
-
-  instead prints as:
-
-  @code{sh}
   expect.cpp:15: error: Expression: 1 == 2 evaluates to false.
   @endcode
 

--- a/include/tts/engine/environment.hpp
+++ b/include/tts/engine/environment.hpp
@@ -59,23 +59,32 @@ namespace tts::_
       ::tts::_::separator();
       out.write("Results: %llu test%s ", test_count, test_txt);
       if(success_count != 0)
+      {
+        out.suite_metric(::tts::outcome::success, success_count, test_count);
         out.write("- %llu/%llu (%2.2f%%) success%s ",
                   success_count,
                   test_count,
                   100.f * static_cast<float>(success_count) / static_cast<float>(test_count),
                   pass_txt);
+      }
       if(failure_count != 0)
+      {
+        out.suite_metric(::tts::outcome::failure, failure_count, test_count);
         out.write("- %llu/%llu (%2.2f%%) failure%s ",
                   failure_count,
                   test_count,
                   100.f * static_cast<float>(failure_count) / static_cast<float>(test_count),
                   fail_txt);
+      }
       if(invalid_count != 0)
+      {
+        out.suite_metric(::tts::outcome::invalid, invalid_count, test_count);
         out.write("- %llu/%llu (%2.2f%%) invalid%s ",
                   invalid_count,
                   test_count,
                   100.f * static_cast<float>(invalid_count) / static_cast<float>(test_count),
                   inv_txt);
+      }
 
       out.writeln();
 

--- a/include/tts/engine/environment.hpp
+++ b/include/tts/engine/environment.hpp
@@ -50,6 +50,12 @@ namespace tts::_
 
       auto& out      = ::tts::output();
 
+      // Fires before separator() too, not just before "Results:" - colorized_sink keeps a color
+      // active across several consecutive lines until the next hook, so this also (deliberately)
+      // colors the separator, and overwrites any color a sink left dangling from the last test if
+      // that test's own closing line was suppressed by -q.
+      out.suite_finished(failure_count, invalid_count);
+
       ::tts::_::separator();
       out.write("Results: %llu test%s ", test_count, test_txt);
       if(success_count != 0)

--- a/include/tts/engine/main.hpp
+++ b/include/tts/engine/main.hpp
@@ -96,21 +96,21 @@ namespace tts::_
   {
     report_type_hint(type);
 
+    ::tts::output().assertion_failed(::tts::text {location}, ::tts::text {message}, false);
+
     if(!::tts::is_quiet())
     {
       ::tts::output().writeln("  [X] %s : ** FAILURE ** : %s", location, message);
     }
-
-    ::tts::output().assertion_failed(::tts::text {location}, ::tts::text {message}, false);
   }
 
   void report_fatal(char const* location, char const* message, ::tts::text const& type)
   {
     report_type_hint(type);
 
-    ::tts::output().writeln("  [@] %s : @@ FATAL @@ : %s", location, message);
-
     ::tts::output().assertion_failed(::tts::text {location}, ::tts::text {message}, true);
+
+    ::tts::output().writeln("  [@] %s : @@ FATAL @@ : %s", location, message);
   }
 
   // Splits the suite in `total` round-robin shards (test at registration index k belongs to
@@ -245,9 +245,12 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
       bool invalid = (test_count == ::tts::global_runtime.test_count);
       bool passed  = !invalid && (failure_count == ::tts::global_runtime.failure_count);
 
+      if(invalid) ::tts::global_runtime.invalid();
+
+      ::tts::output().test_finished(::tts::text {t.name}, passed, invalid);
+
       if(invalid)
       {
-        ::tts::global_runtime.invalid();
         if(!::tts::is_quiet()) ::tts::output().writeln("  [!!]: EMPTY TEST CASE");
         ::tts::output().flush();
       }
@@ -256,12 +259,12 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
         if(!::tts::is_quiet()) ::tts::output().writeln("TEST: '%s' - [PASSED]", t.name);
         ::tts::output().flush();
       }
-
-      ::tts::output().test_finished(::tts::text {t.name}, passed, invalid);
     }
   }
   catch(::tts::_::fatal_signal&)
   {
+    ::tts::output().suite_aborted();
+
     if(!::tts::is_quiet())
       ::tts::output().writeln("@@ ABORTING DUE TO EARLY FAILURE @@ - %d Tests not run",
                               static_cast<int>(nb_tests - done_tests - 1));

--- a/include/tts/sinks/colorized.hpp
+++ b/include/tts/sinks/colorized.hpp
@@ -95,11 +95,12 @@ namespace tts
                       [[maybe_unused]] unsigned long long count,
                       [[maybe_unused]] unsigned long long total) override
     {
+      using enum outcome;
       switch(kind)
       {
-      case outcome::success: set_color("\033[1;32m"); break; // bold green - NOSONAR
-      case outcome::failure: set_color("\033[1;31m"); break; // bold red - NOSONAR
-      case outcome::invalid: set_color("\033[1;33m"); break; // bold yellow - NOSONAR
+      case success: set_color("\033[1;32m"); break; // bold green - NOSONAR
+      case failure: set_color("\033[1;31m"); break; // bold red - NOSONAR
+      case invalid: set_color("\033[1;33m"); break; // bold yellow - NOSONAR
       }
     }
 

--- a/include/tts/sinks/colorized.hpp
+++ b/include/tts/sinks/colorized.hpp
@@ -18,9 +18,10 @@ namespace tts
     @brief output_sink wrapping another sink, colorizing pass/fail/fatal lines with ANSI escapes.
 
     Forwards every message to a target sink (tts::output_handler::default_sink() by default),
-    wrapping a failure/fatal/invalid/pass line, or the final `Results: ...` summary, in the
-    corresponding ANSI color - decided from @ref output_sink's structured hooks, not by parsing
-    text. Opt-in: not every terminal or CI log renders ANSI escapes usefully.
+    wrapping a failure/fatal/invalid/pass line, the separator and `Results: ...` prefix (bold,
+    color-neutral), or each of its outcome segments (bold green/red/yellow), in the corresponding
+    ANSI color - decided from @ref output_sink's structured hooks, not by parsing text. Opt-in:
+    not every terminal or CI log renders ANSI escapes usefully.
 
     @groupheader{Example}
     @code
@@ -84,9 +85,22 @@ namespace tts
       else set_color(nullptr); // plain failure - assertion_failed() already colored its line
     }
 
-    void suite_finished(unsigned long long fail_count, unsigned long long invalid_count) override
+    void suite_finished([[maybe_unused]] unsigned long long fail_count,
+                        [[maybe_unused]] unsigned long long invalid_count) override
     {
-      set_color((fail_count || invalid_count) ? "\033[31m" : "\033[32m"); // NOSONAR
+      set_color("\033[1m"); // bold, neutral - NOSONAR, \o{} is C++23-only
+    }
+
+    void suite_metric(outcome                             kind,
+                      [[maybe_unused]] unsigned long long count,
+                      [[maybe_unused]] unsigned long long total) override
+    {
+      switch(kind)
+      {
+      case outcome::success: set_color("\033[1;32m"); break; // bold green - NOSONAR
+      case outcome::failure: set_color("\033[1;31m"); break; // bold red - NOSONAR
+      case outcome::invalid: set_color("\033[1;33m"); break; // bold yellow - NOSONAR
+      }
     }
 
     void suite_aborted() override

--- a/include/tts/sinks/colorized.hpp
+++ b/include/tts/sinks/colorized.hpp
@@ -18,9 +18,9 @@ namespace tts
     @brief output_sink wrapping another sink, colorizing pass/fail/fatal lines with ANSI escapes.
 
     Forwards every message to a target sink (tts::output_handler::default_sink() by default),
-    wrapping messages that look like a failure, a fatal error, an invalid test, or a pass
-    confirmation in the corresponding ANSI color. Opt-in: not every terminal or CI log renders
-    ANSI escapes usefully.
+    wrapping a failure/fatal/invalid/pass line, or the final `Results: ...` summary, in the
+    corresponding ANSI color - decided from @ref output_sink's structured hooks, not by parsing
+    text. Opt-in: not every terminal or CI log renders ANSI escapes usefully.
 
     @groupheader{Example}
     @code
@@ -41,31 +41,62 @@ namespace tts
       char const* s = t.data();
 
       // A logical line (e.g. the final "Results: ..." summary) can span several write() calls -
-      // keep the color active across all of them until the "\n" that ends the line.
+      // "\n" only closes the CURRENT line's coloring (color_applied_), not active_color_ itself,
+      // so a single hook can color several consecutive lines (e.g. the separator right before
+      // Results:) the same way, until the next hook decides otherwise.
       if(strcmp(s, "\n") == 0) // NOSONAR - avoids std::string
       {
-        if(active_color_) target_->write(text {"\033[0m"}); // NOSONAR - \o{} is C++23-only
-        active_color_ = nullptr;
+        if(color_applied_) target_->write(text {"\033[0m"}); // NOSONAR - \o{} is C++23-only
+        color_applied_ = false;
         target_->write(t);
         return;
       }
 
-      if(!active_color_)
+      if(active_color_ && !color_applied_)
       {
-        // .contains()/\o{} are C++23-only, project targets C++20
-        if(strstr(s, "** FAILURE **") || strstr(s, "@@ FATAL @@") ||      // NOSONAR
-           strstr(s, "@@ ABORTING"))                                      // NOSONAR
-          active_color_ = "\033[31m";                                     // red - NOSONAR
-        else if(strstr(s, "EMPTY TEST CASE")) active_color_ = "\033[33m"; // yellow - NOSONAR
-        else if(strstr(s, "[PASSED]")) active_color_ = "\033[32m";        // green - NOSONAR
-        else if(strncmp(s, "Results:", 8) == 0) // NOSONAR - avoids std::string
-          active_color_ =
-          (strstr(s, "failure") || strstr(s, "invalid")) ? "\033[31m" : "\033[32m"; // NOSONAR
-
-        if(active_color_) target_->write(text {active_color_});
+        target_->write(text {active_color_});
+        color_applied_ = true;
       }
 
       target_->write(t);
+    }
+
+    // Each hook below decisively sets or clears active_color_, rather than only setting it - a
+    // hook whose corresponding text is suppressed by -q must not leave a stale color for some
+    // later, unrelated write() to inherit.
+
+    void test_started([[maybe_unused]] text const& name) override
+    {
+      active_color_  = nullptr;
+      color_applied_ = false;
+    }
+
+    void assertion_failed([[maybe_unused]] text const& location,
+                          [[maybe_unused]] text const& message,
+                          [[maybe_unused]] bool        fatal) override
+    {
+      active_color_  = "\033[31m"; // red - NOSONAR, \o{} is C++23-only
+      color_applied_ = false;
+    }
+
+    void test_finished([[maybe_unused]] text const& name, bool passed, bool invalid) override
+    {
+      if(invalid) active_color_ = "\033[33m";     // yellow - NOSONAR, \o{} is C++23-only
+      else if(passed) active_color_ = "\033[32m"; // green - NOSONAR, \o{} is C++23-only
+      else active_color_ = nullptr; // plain failure - assertion_failed() already colored its line
+      color_applied_ = false;
+    }
+
+    void suite_finished(unsigned long long fail_count, unsigned long long invalid_count) override
+    {
+      active_color_  = (fail_count || invalid_count) ? "\033[31m" : "\033[32m"; // NOSONAR
+      color_applied_ = false;
+    }
+
+    void suite_aborted() override
+    {
+      active_color_  = "\033[31m"; // red - NOSONAR, \o{} is C++23-only
+      color_applied_ = false;
     }
 
     void flush() override
@@ -75,6 +106,7 @@ namespace tts
 
   private:
     output_sink* target_;
-    char const*  active_color_ = nullptr;
+    char const*  active_color_  = nullptr;
+    bool         color_applied_ = false;
   };
 }

--- a/include/tts/sinks/colorized.hpp
+++ b/include/tts/sinks/colorized.hpp
@@ -1,0 +1,77 @@
+//======================================================================================================================
+//! @file
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//======================================================================================================================
+#pragma once
+
+#include <tts/tools/output.hpp>
+
+namespace tts
+{
+  //====================================================================================================================
+  /**
+    @public
+    @brief output_sink wrapping another sink, colorizing pass/fail/fatal lines with ANSI escapes.
+
+    Forwards every message to a target sink (tts::output_handler::default_sink() by default),
+    wrapping messages that look like a failure, a fatal error, an invalid test, or a pass
+    confirmation in the corresponding ANSI color. Opt-in: not every terminal or CI log renders
+    ANSI escapes usefully.
+
+    @groupheader{Example}
+    @code
+    tts::colorized_sink colorized;
+    tts::output().sink(colorized);
+    @endcode
+  **/
+  //====================================================================================================================
+  struct colorized_sink : output_sink
+  {
+    explicit colorized_sink(output_sink& target = output_handler::default_sink())
+        : target_(&target)
+    {
+    }
+
+    void write(text const& t) override
+    {
+      char const* s = t.data();
+
+      // A logical line (e.g. the final "Results: ..." summary) can span several write() calls -
+      // keep the color active across all of them until the "\n" that ends the line.
+      if(strcmp(s, "\n") == 0) // NOSONAR - avoids std::string
+      {
+        if(active_color_) target_->write(text {"\033[0m"});
+        active_color_ = nullptr;
+        target_->write(t);
+        return;
+      }
+
+      if(!active_color_)
+      {
+        if(strstr(s, "** FAILURE **") || strstr(s, "@@ FATAL @@") || strstr(s, "@@ ABORTING"))
+          active_color_ = "\033[31m";                                     // red
+        else if(strstr(s, "EMPTY TEST CASE")) active_color_ = "\033[33m"; // yellow
+        else if(strstr(s, "[PASSED]")) active_color_ = "\033[32m";        // green
+        else if(strncmp(s, "Results:", 8) == 0) // NOSONAR - avoids std::string
+          active_color_ = (strstr(s, "failure") || strstr(s, "invalid")) ? "\033[31m" : "\033[32m";
+
+        if(active_color_) target_->write(text {active_color_});
+      }
+
+      target_->write(t);
+    }
+
+    void flush() override
+    {
+      target_->flush();
+    }
+
+  private:
+    output_sink* target_;
+    char const*  active_color_ = nullptr;
+  };
+}

--- a/include/tts/sinks/colorized.hpp
+++ b/include/tts/sinks/colorized.hpp
@@ -44,7 +44,7 @@ namespace tts
       // keep the color active across all of them until the "\n" that ends the line.
       if(strcmp(s, "\n") == 0) // NOSONAR - avoids std::string
       {
-        if(active_color_) target_->write(text {"\033[0m"});
+        if(active_color_) target_->write(text {"\033[0m"}); // NOSONAR - \o{} is C++23-only
         active_color_ = nullptr;
         target_->write(t);
         return;
@@ -52,12 +52,15 @@ namespace tts
 
       if(!active_color_)
       {
-        if(strstr(s, "** FAILURE **") || strstr(s, "@@ FATAL @@") || strstr(s, "@@ ABORTING"))
-          active_color_ = "\033[31m";                                     // red
-        else if(strstr(s, "EMPTY TEST CASE")) active_color_ = "\033[33m"; // yellow
-        else if(strstr(s, "[PASSED]")) active_color_ = "\033[32m";        // green
+        // .contains()/\o{} are C++23-only, project targets C++20
+        if(strstr(s, "** FAILURE **") || strstr(s, "@@ FATAL @@") ||      // NOSONAR
+           strstr(s, "@@ ABORTING"))                                      // NOSONAR
+          active_color_ = "\033[31m";                                     // red - NOSONAR
+        else if(strstr(s, "EMPTY TEST CASE")) active_color_ = "\033[33m"; // yellow - NOSONAR
+        else if(strstr(s, "[PASSED]")) active_color_ = "\033[32m";        // green - NOSONAR
         else if(strncmp(s, "Results:", 8) == 0) // NOSONAR - avoids std::string
-          active_color_ = (strstr(s, "failure") || strstr(s, "invalid")) ? "\033[31m" : "\033[32m";
+          active_color_ =
+          (strstr(s, "failure") || strstr(s, "invalid")) ? "\033[31m" : "\033[32m"; // NOSONAR
 
         if(active_color_) target_->write(text {active_color_});
       }

--- a/include/tts/sinks/colorized.hpp
+++ b/include/tts/sinks/colorized.hpp
@@ -67,36 +67,31 @@ namespace tts
 
     void test_started([[maybe_unused]] text const& name) override
     {
-      active_color_  = nullptr;
-      color_applied_ = false;
+      set_color(nullptr);
     }
 
     void assertion_failed([[maybe_unused]] text const& location,
                           [[maybe_unused]] text const& message,
                           [[maybe_unused]] bool        fatal) override
     {
-      active_color_  = "\033[31m"; // red - NOSONAR, \o{} is C++23-only
-      color_applied_ = false;
+      set_color("\033[31m"); // red - NOSONAR, \o{} is C++23-only
     }
 
     void test_finished([[maybe_unused]] text const& name, bool passed, bool invalid) override
     {
-      if(invalid) active_color_ = "\033[33m";     // yellow - NOSONAR, \o{} is C++23-only
-      else if(passed) active_color_ = "\033[32m"; // green - NOSONAR, \o{} is C++23-only
-      else active_color_ = nullptr; // plain failure - assertion_failed() already colored its line
-      color_applied_ = false;
+      if(invalid) set_color("\033[33m");     // yellow - NOSONAR, \o{} is C++23-only
+      else if(passed) set_color("\033[32m"); // green - NOSONAR, \o{} is C++23-only
+      else set_color(nullptr); // plain failure - assertion_failed() already colored its line
     }
 
     void suite_finished(unsigned long long fail_count, unsigned long long invalid_count) override
     {
-      active_color_  = (fail_count || invalid_count) ? "\033[31m" : "\033[32m"; // NOSONAR
-      color_applied_ = false;
+      set_color((fail_count || invalid_count) ? "\033[31m" : "\033[32m"); // NOSONAR
     }
 
     void suite_aborted() override
     {
-      active_color_  = "\033[31m"; // red - NOSONAR, \o{} is C++23-only
-      color_applied_ = false;
+      set_color("\033[31m"); // red - NOSONAR, \o{} is C++23-only
     }
 
     void flush() override
@@ -105,6 +100,12 @@ namespace tts
     }
 
   private:
+    void set_color(char const* color)
+    {
+      active_color_  = color;
+      color_applied_ = false;
+    }
+
     output_sink* target_;
     char const*  active_color_  = nullptr;
     bool         color_applied_ = false;

--- a/include/tts/sinks/diagnostics.hpp
+++ b/include/tts/sinks/diagnostics.hpp
@@ -15,13 +15,14 @@ namespace tts
   //====================================================================================================================
   /**
     @public
-    @brief output_sink rewriting failure/fatal lines as compiler-style diagnostics.
+    @brief output_sink adding compiler-style diagnostics for every failing/fatal assertion.
 
-    Forwards every message to a target sink (tts::output_handler::default_sink() by default),
-    rewriting lines that look like a @ref TTS_CASE failure or fatal error - which already embed a
-    `[file:line]` location - into `file:line: error: message` / `file:line: fatal error: message`,
-    so editors/IDEs with a GCC/Clang-style problem matcher (VSCode's `$gcc`, vim's quickfix, ...)
-    can jump straight to the failing assertion. Every other message passes through unchanged.
+    Forwards every message to a target sink (tts::output_handler::default_sink() by default)
+    unchanged, and additionally prints one `file:line: error: message` /
+    `file:line: fatal error: message` line per failing/fatal assertion - built from
+    @ref output_sink's structured `assertion_failed()` hook, not by parsing text - so editors/IDEs
+    with a GCC/Clang-style problem matcher (VSCode's `$gcc`, vim's quickfix, ...) can jump straight
+    to it. Prints even under `-q`, when the raw failure line it complements is itself suppressed.
 
     @groupheader{Example}
     @code
@@ -39,36 +40,19 @@ namespace tts
 
     void write(text const& t) override
     {
-      char const* s      = t.data();
-      char const* marker = "** FAILURE **";
-      char const* level  = "error";
-      char const* found  = strstr(s, marker);
+      target_->write(t);
+    }
 
-      if(!found)
-      {
-        marker = "@@ FATAL @@";
-        level  = "fatal error";
-        found  = strstr(s, marker);
-      }
-
-      // The line looks like "  [X] [file:line] : ** FAILURE ** : message" (or [@] / FATAL) -
-      // find the second bracketed group, the first one being the "[X]"/"[@]" status marker.
-      char const* p1 = found ? strchr(s, '[') : nullptr;
-      char const* e1 = p1 ? strchr(p1, ']') : nullptr;
-      char const* p2 = e1 ? strchr(e1 + 1, '[') : nullptr;
-      char const* e2 = p2 ? strchr(p2, ']') : nullptr;
-
-      if(p2 && e2)
-      {
-        text        location {"%.*s", static_cast<int>(e2 - p2 - 1), p2 + 1}; // NOSONAR
-        char const* msg =
-        found + strlen(marker) + 3; // skip "marker : " - NOSONAR, marker is always a literal
-        target_->write(text {"%s: %s: %s", location.data(), level, msg});
-      }
-      else
-      {
-        target_->write(t);
-      }
+    void assertion_failed(text const& location, text const& message, bool fatal) override
+    {
+      // location is already "[file:line]" (see tts::_::source_location) - strip the brackets.
+      char const* loc = location.data();
+      std::size_t len = strlen(loc);
+      target_->write(text {"%.*s: %s: %s\n",
+                           static_cast<int>(len - 2),
+                           loc + 1,
+                           fatal ? "fatal error" : "error",
+                           message.data()});
     }
 
     void flush() override

--- a/include/tts/sinks/diagnostics.hpp
+++ b/include/tts/sinks/diagnostics.hpp
@@ -1,0 +1,81 @@
+//======================================================================================================================
+//! @file
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//======================================================================================================================
+#pragma once
+
+#include <tts/tools/output.hpp>
+
+namespace tts
+{
+  //====================================================================================================================
+  /**
+    @public
+    @brief output_sink rewriting failure/fatal lines as compiler-style diagnostics.
+
+    Forwards every message to a target sink (tts::output_handler::default_sink() by default),
+    rewriting lines that look like a @ref TTS_CASE failure or fatal error - which already embed a
+    `[file:line]` location - into `file:line: error: message` / `file:line: fatal error: message`,
+    so editors/IDEs with a GCC/Clang-style problem matcher (VSCode's `$gcc`, vim's quickfix, ...)
+    can jump straight to the failing assertion. Every other message passes through unchanged.
+
+    @groupheader{Example}
+    @code
+    tts::diagnostics_sink diagnostics;
+    tts::output().sink(diagnostics);
+    @endcode
+  **/
+  //====================================================================================================================
+  struct diagnostics_sink : output_sink
+  {
+    explicit diagnostics_sink(output_sink& target = output_handler::default_sink())
+        : target_(&target)
+    {
+    }
+
+    void write(text const& t) override
+    {
+      char const* s      = t.data();
+      char const* marker = "** FAILURE **";
+      char const* level  = "error";
+      char const* found  = strstr(s, marker);
+
+      if(!found)
+      {
+        marker = "@@ FATAL @@";
+        level  = "fatal error";
+        found  = strstr(s, marker);
+      }
+
+      // The line looks like "  [X] [file:line] : ** FAILURE ** : message" (or [@] / FATAL) -
+      // find the second bracketed group, the first one being the "[X]"/"[@]" status marker.
+      char const* p1 = found ? strchr(s, '[') : nullptr;
+      char const* e1 = p1 ? strchr(p1, ']') : nullptr;
+      char const* p2 = e1 ? strchr(e1 + 1, '[') : nullptr;
+      char const* e2 = p2 ? strchr(p2, ']') : nullptr;
+
+      if(p2 && e2)
+      {
+        text        location {"%.*s", static_cast<int>(e2 - p2 - 1), p2 + 1}; // NOSONAR
+        char const* msg = found + strlen(marker) + 3;                         // skip "marker : "
+        target_->write(text {"%s: %s: %s", location.data(), level, msg});
+      }
+      else
+      {
+        target_->write(t);
+      }
+    }
+
+    void flush() override
+    {
+      target_->flush();
+    }
+
+  private:
+    output_sink* target_;
+  };
+}

--- a/include/tts/sinks/diagnostics.hpp
+++ b/include/tts/sinks/diagnostics.hpp
@@ -61,7 +61,8 @@ namespace tts
       if(p2 && e2)
       {
         text        location {"%.*s", static_cast<int>(e2 - p2 - 1), p2 + 1}; // NOSONAR
-        char const* msg = found + strlen(marker) + 3;                         // skip "marker : "
+        char const* msg =
+        found + strlen(marker) + 3; // skip "marker : " - NOSONAR, marker is always a literal
         target_->write(text {"%s: %s: %s", location.data(), level, msg});
       }
       else

--- a/include/tts/sinks/diagnostics.hpp
+++ b/include/tts/sinks/diagnostics.hpp
@@ -47,7 +47,7 @@ namespace tts
     {
       // location is already "[file:line]" (see tts::_::source_location) - strip the brackets.
       char const* loc = location.data();
-      std::size_t len = strlen(loc);
+      std::size_t len = strlen(loc); // NOSONAR - loc always comes from a well-formed tts::text
       target_->write(text {"%.*s: %s: %s\n",
                            static_cast<int>(len - 2),
                            loc + 1,

--- a/include/tts/sinks/sinks.hpp
+++ b/include/tts/sinks/sinks.hpp
@@ -1,0 +1,13 @@
+//======================================================================================================================
+//! @file
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//======================================================================================================================
+#pragma once
+
+#include <tts/sinks/colorized.hpp>
+#include <tts/sinks/diagnostics.hpp>
+#include <tts/sinks/tap.hpp>

--- a/include/tts/sinks/tap.hpp
+++ b/include/tts/sinks/tap.hpp
@@ -15,14 +15,14 @@ namespace tts
   //====================================================================================================================
   /**
     @public
-    @brief output_sink gathering every message, then rendering it as TAP (Test Anything Protocol).
+    @brief output_sink rendering the run as TAP (Test Anything Protocol).
 
-    Accumulates the run's output like tts::gathering_sink, then dump() reconstructs one "ok N -
-    name" / "not ok N - name" line per @ref TTS_CASE from it, followed by a trailing "1..N" plan
-    line. This is derived from the same human-readable text @ref tts::stdout_sink prints - there
-    is no structured per-test event to draw from yet - so it only recognizes TTS's own "TEST:
-    'name'" / "[PASSED]" markers and does not (currently) reflect @ref TTS_CASE_TPL's per-type
-    breakdown or @ref TTS_WHEN / @ref TTS_AND_THEN sub-scenarios.
+    Built from @ref output_sink's structured `test_finished` hook rather than by parsing the
+    human-readable text @ref tts::stdout_sink prints, so it reports one "ok N - name" / "not ok
+    N - name" line per @ref TTS_CASE regardless of `-v`/`-q`, followed by a trailing "1..N" plan
+    line once dump()ed. It does not (currently) reflect @ref TTS_CASE_TPL's per-type breakdown or
+    @ref TTS_WHEN / @ref TTS_AND_THEN sub-scenarios, since those don't have their own hook - only
+    the enclosing @ref TTS_CASE does.
 
     @groupheader{Example}
     @code
@@ -37,64 +37,32 @@ namespace tts
   //====================================================================================================================
   struct tap_sink : output_sink
   {
-    void write(text const& t) override
+    void write(text const&) override
     {
-      buffer_ += t;
+      // Intentionally empty: TAP output is built entirely from test_finished() below.
+    }
+
+    void test_finished(text const& name, bool passed, [[maybe_unused]] bool invalid) override
+    {
+      ++count_;
+      body_ += passed ? text {"ok %zu - %s\n", count_, name.data()}
+                      : text {"not ok %zu - %s\n", count_, name.data()};
     }
 
     /// Renders everything gathered so far as TAP-formatted text.
     text render() const
     {
-      text        out;
-      text        pending;
-      std::size_t n = 0;
-
-      char const* p = buffer_.data();
-      while(*p)
-      {
-        char const* nl  = strchr(p, '\n');
-        std::size_t len = nl ? static_cast<std::size_t>(nl - p) : strlen(p);
-        text        line {"%.*s", static_cast<int>(len), p}; // NOSONAR - avoids std::string
-
-        if(strncmp(line.data(), "TEST: '", 7) == 0 && !strstr(line.data(), "[PASSED]"))
-        {
-          if(!pending.is_empty())
-          {
-            ++n;
-            out += text {"not ok %zu - %s\n", n, pending.data()};
-          }
-
-          char const* start = line.data() + 7;
-          char const* end   = strchr(start, '\'');
-          pending           = end ? text {"%.*s", static_cast<int>(end - start), start} : text {};
-        }
-        else if(!pending.is_empty() && strstr(line.data(), "[PASSED]"))
-        {
-          ++n;
-          out     += text {"ok %zu - %s\n", n, pending.data()};
-          pending  = text {};
-        }
-
-        p = nl ? nl + 1 : p + len;
-      }
-
-      if(!pending.is_empty())
-      {
-        ++n;
-        out += text {"not ok %zu - %s\n", n, pending.data()};
-      }
-
-      return text {"1..%zu\n", n} + out;
+      return text {"1..%zu\n", count_} + body_;
     }
 
-    /// Forwards the TAP-rendered report to target, then clears the gathered buffer.
+    /// Forwards the TAP-rendered report to target, then clears the gathered results.
     void dump(output_sink& target)
     {
       target.write(render());
       clear();
     }
 
-    /// Streams the TAP-rendered report to `stdout`, then clears the gathered buffer.
+    /// Streams the TAP-rendered report to `stdout`, then clears the gathered results.
     void dump()
     {
       stdout_sink target;
@@ -104,10 +72,12 @@ namespace tts
     /// Discards everything gathered so far.
     void clear()
     {
-      buffer_ = text {};
+      body_  = text {};
+      count_ = 0;
     }
 
   private:
-    text buffer_;
+    text        body_;
+    std::size_t count_ = 0;
   };
 }

--- a/include/tts/sinks/tap.hpp
+++ b/include/tts/sinks/tap.hpp
@@ -1,0 +1,113 @@
+//======================================================================================================================
+//! @file
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//======================================================================================================================
+#pragma once
+
+#include <tts/tools/output.hpp>
+
+namespace tts
+{
+  //====================================================================================================================
+  /**
+    @public
+    @brief output_sink gathering every message, then rendering it as TAP (Test Anything Protocol).
+
+    Accumulates the run's output like tts::gathering_sink, then dump() reconstructs one "ok N -
+    name" / "not ok N - name" line per @ref TTS_CASE from it, followed by a trailing "1..N" plan
+    line. This is derived from the same human-readable text @ref tts::stdout_sink prints - there
+    is no structured per-test event to draw from yet - so it only recognizes TTS's own "TEST:
+    'name'" / "[PASSED]" markers and does not (currently) reflect @ref TTS_CASE_TPL's per-type
+    breakdown or @ref TTS_WHEN / @ref TTS_AND_THEN sub-scenarios.
+
+    @groupheader{Example}
+    @code
+    tts::tap_sink tap;
+    tts::output().sink(tap);
+
+    // ... run the test suite ...
+
+    tap.dump(); // stream the TAP-formatted report to stdout
+    @endcode
+  **/
+  //====================================================================================================================
+  struct tap_sink : output_sink
+  {
+    void write(text const& t) override
+    {
+      buffer_ += t;
+    }
+
+    /// Renders everything gathered so far as TAP-formatted text.
+    text render() const
+    {
+      text        out;
+      text        pending;
+      std::size_t n = 0;
+
+      char const* p = buffer_.data();
+      while(*p)
+      {
+        char const* nl  = strchr(p, '\n');
+        std::size_t len = nl ? static_cast<std::size_t>(nl - p) : strlen(p);
+        text        line {"%.*s", static_cast<int>(len), p}; // NOSONAR - avoids std::string
+
+        if(strncmp(line.data(), "TEST: '", 7) == 0 && !strstr(line.data(), "[PASSED]"))
+        {
+          if(!pending.is_empty())
+          {
+            ++n;
+            out += text {"not ok %zu - %s\n", n, pending.data()};
+          }
+
+          char const* start = line.data() + 7;
+          char const* end   = strchr(start, '\'');
+          pending           = end ? text {"%.*s", static_cast<int>(end - start), start} : text {};
+        }
+        else if(!pending.is_empty() && strstr(line.data(), "[PASSED]"))
+        {
+          ++n;
+          out     += text {"ok %zu - %s\n", n, pending.data()};
+          pending  = text {};
+        }
+
+        p = nl ? nl + 1 : p + len;
+      }
+
+      if(!pending.is_empty())
+      {
+        ++n;
+        out += text {"not ok %zu - %s\n", n, pending.data()};
+      }
+
+      return text {"1..%zu\n", n} + out;
+    }
+
+    /// Forwards the TAP-rendered report to target, then clears the gathered buffer.
+    void dump(output_sink& target)
+    {
+      target.write(render());
+      clear();
+    }
+
+    /// Streams the TAP-rendered report to `stdout`, then clears the gathered buffer.
+    void dump()
+    {
+      stdout_sink target;
+      dump(target);
+    }
+
+    /// Discards everything gathered so far.
+    void clear()
+    {
+      buffer_ = text {};
+    }
+
+  private:
+    text buffer_;
+  };
+}

--- a/include/tts/tools/output.hpp
+++ b/include/tts/tools/output.hpp
@@ -109,9 +109,10 @@ namespace tts
       // Intentionally empty: most sinks only care about the formatted text stream.
     }
 
-    /// Called once per failing/fatal assertion, right before the corresponding text is written.
-    /// No-op by default. Not called for passing assertions - test_finished()'s `passed` already
-    /// covers that case, and most consumers of this hook don't want one event per assertion.
+    /// Called once per failing/fatal assertion, always - even under -q, where the corresponding
+    /// text (if any) is suppressed instead of being written first. No-op by default. Not called
+    /// for passing assertions - test_finished()'s `passed` already covers that case, and most
+    /// consumers of this hook don't want one event per assertion.
     virtual void assertion_failed([[maybe_unused]] text const& location,
                                   [[maybe_unused]] text const& message,
                                   [[maybe_unused]] bool        fatal)

--- a/include/tts/tools/output.hpp
+++ b/include/tts/tools/output.hpp
@@ -109,10 +109,10 @@ namespace tts
       // Intentionally empty: most sinks only care about the formatted text stream.
     }
 
-    /// Called once per failing/fatal assertion, always - even under -q, where the corresponding
-    /// text (if any) is suppressed instead of being written first. No-op by default. Not called
-    /// for passing assertions - test_finished()'s `passed` already covers that case, and most
-    /// consumers of this hook don't want one event per assertion.
+    /// Called once per failing/fatal assertion, always and before the corresponding text (if
+    /// any - it's suppressed under -q for a plain failure, though never for a fatal one). No-op
+    /// by default. Not called for passing assertions - test_finished()'s `passed` already covers
+    /// that case, and most consumers of this hook don't want one event per assertion.
     virtual void assertion_failed([[maybe_unused]] text const& location,
                                   [[maybe_unused]] text const& message,
                                   [[maybe_unused]] bool        fatal)
@@ -121,10 +121,26 @@ namespace tts
     }
 
     /// Called once a @ref TTS_CASE / @ref TTS_CASE_TPL / @ref TTS_CASE_WITH has finished
-    /// running, with its outcome. No-op by default.
+    /// running, always and before its corresponding text (if any - suppressed under -q), with
+    /// its outcome. No-op by default.
     virtual void test_finished([[maybe_unused]] text const& name,
                                [[maybe_unused]] bool        passed,
                                [[maybe_unused]] bool        invalid)
+    {
+      // Intentionally empty: most sinks only care about the formatted text stream.
+    }
+
+    /// Called once the whole suite has finished running (from tts::report()), with its aggregate
+    /// outcome, always - even under -q. No-op by default.
+    virtual void suite_finished([[maybe_unused]] unsigned long long fail_count,
+                                [[maybe_unused]] unsigned long long invalid_count)
+    {
+      // Intentionally empty: most sinks only care about the formatted text stream.
+    }
+
+    /// Called if the suite aborts early due to a @ref TTS_FATAL failure, before tts::report()
+    /// (and thus suite_finished()) runs. No-op by default.
+    virtual void suite_aborted()
     {
       // Intentionally empty: most sinks only care about the formatted text stream.
     }
@@ -297,6 +313,18 @@ namespace tts
     void test_finished(text const& name, bool passed, bool invalid)
     {
       sink_->test_finished(name, passed, invalid);
+    }
+
+    /// Notifies the current output_sink that the whole suite has finished running.
+    void suite_finished(unsigned long long fail_count, unsigned long long invalid_count)
+    {
+      sink_->suite_finished(fail_count, invalid_count);
+    }
+
+    /// Notifies the current output_sink that the suite aborted early on a fatal failure.
+    void suite_aborted()
+    {
+      sink_->suite_aborted();
     }
 
     /// Installs s as the output_sink every subsequent write goes to.

--- a/include/tts/tools/output.hpp
+++ b/include/tts/tools/output.hpp
@@ -74,6 +74,20 @@ namespace tts
   //====================================================================================================================
   /**
     @public
+    @brief The three ways a @ref TTS_CASE outcome is tallied in the `Results: ...` summary.
+    @see output_sink::suite_metric
+  **/
+  //====================================================================================================================
+  enum class outcome
+  {
+    success,
+    failure,
+    invalid
+  };
+
+  //====================================================================================================================
+  /**
+    @public
     @brief Customization point for where TTS output actually goes.
 
     All non-usage related output produced while running a test suite - tests progress, pass/fail/
@@ -134,6 +148,15 @@ namespace tts
     /// outcome, always - even under -q. No-op by default.
     virtual void suite_finished([[maybe_unused]] unsigned long long fail_count,
                                 [[maybe_unused]] unsigned long long invalid_count)
+    {
+      // Intentionally empty: most sinks only care about the formatted text stream.
+    }
+
+    /// Called once per non-zero outcome category, right before its "N/M (P%) <label>" segment is
+    /// printed as part of the `Results: ...` summary. No-op by default.
+    virtual void suite_metric([[maybe_unused]] outcome            kind,
+                              [[maybe_unused]] unsigned long long count,
+                              [[maybe_unused]] unsigned long long total)
     {
       // Intentionally empty: most sinks only care about the formatted text stream.
     }
@@ -319,6 +342,12 @@ namespace tts
     void suite_finished(unsigned long long fail_count, unsigned long long invalid_count)
     {
       sink_->suite_finished(fail_count, invalid_count);
+    }
+
+    /// Notifies the current output_sink that a Results: outcome category is about to print.
+    void suite_metric(outcome kind, unsigned long long count, unsigned long long total)
+    {
+      sink_->suite_metric(kind, count, total);
     }
 
     /// Notifies the current output_sink that the suite aborted early on a fatal failure.

--- a/include/tts/tts.hpp
+++ b/include/tts/tts.hpp
@@ -26,6 +26,7 @@ namespace tts
 #include <tts/engine/deps.hpp>
 #include <tts/engine/main.hpp>
 #include <tts/engine/case.hpp>
+#include <tts/sinks/sinks.hpp>
 
 #include <tts/test/basic.hpp>
 #include <tts/test/exceptions.hpp>

--- a/test/unit/tests/sinks.cpp
+++ b/test/unit/tests/sinks.cpp
@@ -60,7 +60,7 @@ int main(int argc, char const** argv)
     ok = ok && (strstr(content, "not ok 2 - Failing case for sink tests") != nullptr); // NOSONAR
   }
 
-  // diagnostics_sink rewrites failure lines as "file:line: error: message".
+  // diagnostics_sink adds a "file:line: error: message" line per failing/fatal assertion.
   {
     tts::gathering_sink   target;
     tts::diagnostics_sink diagnostics {target};

--- a/test/unit/tests/sinks.cpp
+++ b/test/unit/tests/sinks.cpp
@@ -1,0 +1,79 @@
+//==================================================================================================
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#define TTS_MAIN
+#define TTS_CUSTOM_DRIVER_FUNCTION sinks_test_main
+#include <tts/tts.hpp>
+
+TTS_CASE("Passing case for sink tests")
+{
+  TTS_EXPECT(1 == 1);
+};
+
+TTS_CASE("Failing case for sink tests")
+{
+  TTS_EXPECT(1 == 2);
+};
+
+int main(int argc, char const** argv)
+{
+  ::tts::initialize(argc, argv);
+
+  bool ok = true;
+
+  // colorized_sink wraps a target sink and colors PASSED/FAILURE lines, including the
+  // multi-fragment "Results: ..." summary, without breaking any content through.
+  {
+    tts::gathering_sink target;
+    tts::colorized_sink colorized {target};
+    {
+      tts::scoped_sink scope(colorized);
+      sinks_test_main(argc, argv);
+    }
+
+    char const* content = target.content().data();
+    ok                  = ok && (strstr(content, "\033[32m") != nullptr);   // NOSONAR - green
+    ok                  = ok && (strstr(content, "\033[31m") != nullptr);   // NOSONAR - red
+    ok                  = ok && (strstr(content, "\033[0m") != nullptr);    // NOSONAR - reset
+    ok = ok && (strstr(content, "Passing case for sink tests") != nullptr); // NOSONAR
+    ok = ok && (strstr(content, "Failing case for sink tests") != nullptr); // NOSONAR
+  }
+
+  // tap_sink reconstructs "1..N" / "ok" / "not ok" lines from the captured text.
+  {
+    tts::tap_sink tap;
+    {
+      tts::scoped_sink scope(tap);
+      sinks_test_main(argc, argv);
+    }
+
+    tts::gathering_sink target;
+    tap.dump(target);
+    char const* content = target.content().data();
+
+    ok                  = ok && (strstr(content, "1..2") != nullptr);                  // NOSONAR
+    ok = ok && (strstr(content, "ok 1 - Passing case for sink tests") != nullptr);     // NOSONAR
+    ok = ok && (strstr(content, "not ok 2 - Failing case for sink tests") != nullptr); // NOSONAR
+  }
+
+  // diagnostics_sink rewrites failure lines as "file:line: error: message".
+  {
+    tts::gathering_sink   target;
+    tts::diagnostics_sink diagnostics {target};
+    {
+      tts::scoped_sink scope(diagnostics);
+      sinks_test_main(argc, argv);
+    }
+
+    char const* content = target.content().data();
+    ok                  = ok && (strstr(content, "sinks.cpp:") != nullptr); // NOSONAR
+    ok                  = ok &&
+         (strstr(content, ": error: Expression: 1 == 2 evaluates to false.") != nullptr); // NOSONAR
+  }
+
+  return ok ? 0 : 1;
+}

--- a/test/unit/tests/sinks.cpp
+++ b/test/unit/tests/sinks.cpp
@@ -43,9 +43,12 @@ int main(int argc, char const** argv)
     ok = ok && (strstr(content, "Passing case for sink tests") != nullptr); // NOSONAR
     ok = ok && (strstr(content, "Failing case for sink tests") != nullptr); // NOSONAR
 
-    // The Results: summary itself (not just some earlier line) must be red, since this suite has
-    // a failure - it stays active color across the separator right above it too.
-    ok = ok && (strstr(content, "\033[31mResults:") != nullptr); // NOSONAR
+    // The separator and the "Results:" prefix are bold neutral, not tied to pass/fail; only each
+    // score segment (success/failure/invalid) is colored, per its own category.
+    ok = ok && (strstr(content, "\033[1m--------") != nullptr); // NOSONAR
+    ok = ok && (strstr(content, "\033[1mResults:") != nullptr); // NOSONAR
+    ok = ok && (strstr(content, "\033[1;32m- 1/2") != nullptr); // NOSONAR - success
+    ok = ok && (strstr(content, "\033[1;31m- 1/2") != nullptr); // NOSONAR - failure
   }
 
   // tap_sink renders "1..N" / "ok" / "not ok" lines from the structured test_finished() events.

--- a/test/unit/tests/sinks.cpp
+++ b/test/unit/tests/sinks.cpp
@@ -33,6 +33,7 @@ int main(int argc, char const** argv)
     {
       tts::scoped_sink scope(colorized);
       sinks_test_main(argc, argv);
+      tts::report(1, 0); // emits the "Results: ..." summary this block also checks below
     }
 
     char const* content = target.content().data();
@@ -41,6 +42,10 @@ int main(int argc, char const** argv)
     ok                  = ok && (strstr(content, "\033[0m") != nullptr);    // NOSONAR - reset
     ok = ok && (strstr(content, "Passing case for sink tests") != nullptr); // NOSONAR
     ok = ok && (strstr(content, "Failing case for sink tests") != nullptr); // NOSONAR
+
+    // The Results: summary itself (not just some earlier line) must be red, since this suite has
+    // a failure - it stays active color across the separator right above it too.
+    ok = ok && (strstr(content, "\033[31mResults:") != nullptr); // NOSONAR
   }
 
   // tap_sink renders "1..N" / "ok" / "not ok" lines from the structured test_finished() events.

--- a/test/unit/tests/sinks.cpp
+++ b/test/unit/tests/sinks.cpp
@@ -43,7 +43,7 @@ int main(int argc, char const** argv)
     ok = ok && (strstr(content, "Failing case for sink tests") != nullptr); // NOSONAR
   }
 
-  // tap_sink reconstructs "1..N" / "ok" / "not ok" lines from the captured text.
+  // tap_sink renders "1..N" / "ok" / "not ok" lines from the structured test_finished() events.
   {
     tts::tap_sink tap;
     {

--- a/test/unit/tests/structured_sink.cpp
+++ b/test/unit/tests/structured_sink.cpp
@@ -52,6 +52,11 @@ namespace
       "FINISHED name=%s passed=%d invalid=%d\n", name.data(), passed ? 1 : 0, invalid ? 1 : 0};
     }
 
+    void suite_finished(unsigned long long fail_count, unsigned long long invalid_count) override
+    {
+      log += tts::text {"SUITE_FINISHED fails=%llu invalids=%llu\n", fail_count, invalid_count};
+    }
+
     tts::text log;
   };
 }
@@ -64,6 +69,7 @@ int main(int argc, char const** argv)
   {
     tts::scoped_sink scope(sink);
     structured_sink_main(argc, argv);
+    tts::report(1, 1); // triggers suite_finished() with this suite's actual fail/invalid counts
   }
 
   bool        ok  = true;
@@ -92,6 +98,8 @@ int main(int argc, char const** argv)
   ok &&
   (strstr(log, "FINISHED name=Invalid case for structured hooks passed=0 invalid=1\n") // NOSONAR
    != nullptr);
+
+  ok = ok && (strstr(log, "SUITE_FINISHED fails=1 invalids=1\n") != nullptr); // NOSONAR
 
   return ok ? 0 : 1;
 }

--- a/test/unit/tests/suite_aborted.cpp
+++ b/test/unit/tests/suite_aborted.cpp
@@ -1,0 +1,46 @@
+//==================================================================================================
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#define TTS_MAIN
+#define TTS_CUSTOM_DRIVER_FUNCTION suite_aborted_main
+#include <tts/tts.hpp>
+
+TTS_CASE("Fatal case triggering an early abort")
+{
+  TTS_FATAL("boom");
+};
+
+namespace
+{
+  struct recording_sink : tts::output_sink
+  {
+    void write(tts::text const&) override
+    {
+      // Unused: this test only exercises the suite_aborted() hook.
+    }
+
+    void suite_aborted() override
+    {
+      aborted = true;
+    }
+
+    bool aborted = false;
+  };
+}
+
+int main(int argc, char const** argv)
+{
+  ::tts::initialize(argc, argv);
+
+  recording_sink sink;
+  {
+    tts::scoped_sink scope(sink);
+    suite_aborted_main(argc, argv);
+  }
+
+  return sink.aborted ? 0 : 1;
+}


### PR DESCRIPTION
Adds the three Easy-tier built-in output sinks tracked in #164: tts::colorized_sink (ANSI pass/fail coloring), tts::tap_sink (TAP-formatted report), and tts::diagnostics_sink (compiler-style problem-matcher output). All three live under tts/sinks/*, included via sinks/sinks.hpp from tts.hpp.

tap_sink is built on the new structured test_finished() hook (from #191) rather than parsing the formatted text stream, so it stays correct under -q. Documented under a new "Built-in Output Sinks" page linked from the How-Tos nav.