### PR TITLE
Add per-test timing, always measured, passed to sinks

### DIFF
--- a/doc/cli.hpp
+++ b/doc/cli.hpp
@@ -52,7 +52,7 @@
   `--help`        | `-h`     | Display the list of supported options `./my_test --help`
   `--hex`         | `-x`     | Display floating point values as hexadecimal. `./my_test --hex`
   `--scientific`  | `-s`     | Display floating point values as hexadecimal. `./my_test --scientific`
-  `--verbose`     | `-v`     | Display tests results regardless of their status. `./my_test --verbose`
+  `--verbose`     | `-v`     | Display tests results regardless of their status, and their duration. `./my_test --verbose`
   `--quiet`       | `-q`     | Remove all tests results regardless of their status. `./my_test --quiet`
 
   # Execution Control

--- a/include/tts/engine/environment.hpp
+++ b/include/tts/engine/environment.hpp
@@ -88,6 +88,10 @@ namespace tts::_
 
       out.writeln();
 
+      double total_ms = static_cast<double>(total_duration_ns) / 1'000'000.0;
+      double avg_ms   = test_count ? total_ms / static_cast<double>(test_count) : 0.0;
+      out.writeln("Total Time: %.3f ms - %.3f ms/test", total_ms, avg_ms);
+
       // A shard landing on zero tests is an expected partition outcome, not a build/
       // registration bug, so --shard implicitly behaves like --allow-empty here.
       if(test_count == 0 && !::tts::arguments()("--allow-empty") && !::tts::arguments()("--shard"))
@@ -97,9 +101,13 @@ namespace tts::_
       else return (failure_count == fails && invalid_count == invalids) ? 0 : 1;
     }
 
-    unsigned long long test_count = 0, success_count = 0, failure_count = 0, fatal_count = 0,
-                       invalid_count = 0;
-    bool fail_status                 = false;
+    unsigned long long test_count        = 0;
+    unsigned long long success_count     = 0;
+    unsigned long long failure_count     = 0;
+    unsigned long long fatal_count       = 0;
+    unsigned long long invalid_count     = 0;
+    unsigned long long total_duration_ns = 0;
+    bool               fail_status       = false;
   };
 }
 

--- a/include/tts/engine/environment.hpp
+++ b/include/tts/engine/environment.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <tts/engine/deps.hpp>
+#include <tts/tools/clock.hpp>
 #include <tts/tools/options.hpp>
 #include <tts/tools/output.hpp>
 
@@ -88,9 +89,11 @@ namespace tts::_
 
       out.writeln();
 
-      double total_ms = static_cast<double>(total_duration_ns) / 1'000'000.0;
-      double avg_ms   = test_count ? total_ms / static_cast<double>(test_count) : 0.0;
-      out.writeln("Total Time: %.3f ms - %.3f ms/test", total_ms, avg_ms);
+      double avg_duration_ns =
+      test_count ? static_cast<double>(total_duration_ns) / static_cast<double>(test_count) : 0.0;
+      out.writeln("Total Time: %s - %s/test",
+                  ::tts::_::format_duration(static_cast<double>(total_duration_ns)).data(),
+                  ::tts::_::format_duration(avg_duration_ns).data());
 
       // A shard landing on zero tests is an expected partition outcome, not a build/
       // registration bug, so --shard implicitly behaves like --allow-empty here.

--- a/include/tts/engine/main.hpp
+++ b/include/tts/engine/main.hpp
@@ -14,6 +14,7 @@
 #include <tts/engine/environment.hpp>
 #include <tts/engine/shard.hpp>
 #include <tts/engine/sink_selection.hpp>
+#include <tts/tools/clock.hpp>
 #include <tts/tools/file.hpp>
 #include <tts/tools/options.hpp>
 #include <tts/tools/random.hpp>
@@ -228,24 +229,48 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
 
       if(!::tts::is_quiet()) ::tts::output().writeln("TEST: '%s'", t.name);
       ::tts::output().flush();
+
+      // Always measured, regardless of --verbose: sinks (and the aggregate Total Time: line)
+      // need it even when the per-test text display below doesn't show it.
+      auto start_ns = ::tts::_::now_ns();
       t();
+      auto duration_ns = ::tts::_::now_ns() - start_ns;
       done_tests++;
 
-      bool invalid = (test_count == ::tts::global_runtime.test_count);
-      bool passed  = !invalid && (failure_count == ::tts::global_runtime.failure_count);
+      ::tts::global_runtime.total_duration_ns += duration_ns;
+
+      bool invalid                             = (test_count == ::tts::global_runtime.test_count);
+      bool passed = !invalid && (failure_count == ::tts::global_runtime.failure_count);
 
       if(invalid) ::tts::global_runtime.invalid();
 
-      ::tts::output().test_finished(::tts::text {t.name}, passed, invalid);
+      ::tts::output().test_finished(::tts::text {t.name}, passed, invalid, duration_ns);
+
+      double duration_ms = static_cast<double>(duration_ns) / 1'000'000.0;
 
       if(invalid)
       {
-        if(!::tts::is_quiet()) ::tts::output().writeln("  [!!]: EMPTY TEST CASE");
+        if(!::tts::is_quiet())
+        {
+          if(::tts::is_verbose())
+            ::tts::output().writeln("  [!!]: EMPTY TEST CASE (%.3fms)", duration_ms);
+          else ::tts::output().writeln("  [!!]: EMPTY TEST CASE");
+        }
         ::tts::output().flush();
       }
       else if(passed)
       {
-        if(!::tts::is_quiet()) ::tts::output().writeln("TEST: '%s' - [PASSED]", t.name);
+        if(!::tts::is_quiet())
+        {
+          if(::tts::is_verbose())
+            ::tts::output().writeln("TEST: '%s' - [PASSED] (%.3fms)", t.name, duration_ms);
+          else ::tts::output().writeln("TEST: '%s' - [PASSED]", t.name);
+        }
+        ::tts::output().flush();
+      }
+      else if(::tts::is_verbose() && !::tts::is_quiet())
+      {
+        ::tts::output().writeln("TEST: '%s' - (%.3fms)", t.name, duration_ms);
         ::tts::output().flush();
       }
     }

--- a/include/tts/engine/main.hpp
+++ b/include/tts/engine/main.hpp
@@ -252,9 +252,10 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
       {
         if(!::tts::is_quiet())
         {
-          if(::tts::is_verbose())
-            ::tts::output().writeln("  [!!]: EMPTY TEST CASE (%.3fms)", duration_ms);
-          else ::tts::output().writeln("  [!!]: EMPTY TEST CASE");
+          ::tts::text line = ::tts::is_verbose()
+                             ? ::tts::text {"  [!!]: EMPTY TEST CASE (%.3fms)", duration_ms}
+                             : ::tts::text {"  [!!]: EMPTY TEST CASE"};
+          ::tts::output().writeln(line);
         }
         ::tts::output().flush();
       }
@@ -262,9 +263,10 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
       {
         if(!::tts::is_quiet())
         {
-          if(::tts::is_verbose())
-            ::tts::output().writeln("TEST: '%s' - [PASSED] (%.3fms)", t.name, duration_ms);
-          else ::tts::output().writeln("TEST: '%s' - [PASSED]", t.name);
+          ::tts::text line = ::tts::is_verbose()
+                             ? ::tts::text {"TEST: '%s' - [PASSED] (%.3fms)", t.name, duration_ms}
+                             : ::tts::text {"TEST: '%s' - [PASSED]", t.name};
+          ::tts::output().writeln(line);
         }
         ::tts::output().flush();
       }

--- a/include/tts/engine/main.hpp
+++ b/include/tts/engine/main.hpp
@@ -246,14 +246,14 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
 
       ::tts::output().test_finished(::tts::text {t.name}, passed, invalid, duration_ns);
 
-      double duration_ms = static_cast<double>(duration_ns) / 1'000'000.0;
+      ::tts::text duration_txt = ::tts::_::format_duration(static_cast<double>(duration_ns));
 
       if(invalid)
       {
         if(!::tts::is_quiet())
         {
           ::tts::text line = ::tts::is_verbose()
-                             ? ::tts::text {"  [!!]: EMPTY TEST CASE (%.3fms)", duration_ms}
+                             ? ::tts::text {"  [!!]: EMPTY TEST CASE (%s)", duration_txt.data()}
                              : ::tts::text {"  [!!]: EMPTY TEST CASE"};
           ::tts::output().writeln(line);
         }
@@ -263,16 +263,17 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
       {
         if(!::tts::is_quiet())
         {
-          ::tts::text line = ::tts::is_verbose()
-                             ? ::tts::text {"TEST: '%s' - [PASSED] (%.3fms)", t.name, duration_ms}
-                             : ::tts::text {"TEST: '%s' - [PASSED]", t.name};
+          ::tts::text line =
+          ::tts::is_verbose()
+          ? ::tts::text {"TEST: '%s' - [PASSED] (%s)", t.name, duration_txt.data()}
+          : ::tts::text {"TEST: '%s' - [PASSED]", t.name};
           ::tts::output().writeln(line);
         }
         ::tts::output().flush();
       }
       else if(::tts::is_verbose() && !::tts::is_quiet())
       {
-        ::tts::output().writeln("TEST: '%s' - (%.3fms)", t.name, duration_ms);
+        ::tts::output().writeln("TEST: '%s' - (%s)", t.name, duration_txt.data());
         ::tts::output().flush();
       }
     }

--- a/include/tts/sinks/colorized.hpp
+++ b/include/tts/sinks/colorized.hpp
@@ -59,6 +59,16 @@ namespace tts
       }
 
       target_->write(t);
+
+      // suite_metric() colors only its own segment (one write() call), not everything after it
+      // like the other hooks - once that segment is written, fall back to whatever color (if
+      // any) was active before it, e.g. bold-neutral for the Results: line it's part of.
+      if(revert_to_)
+      {
+        active_color_  = revert_to_;
+        color_applied_ = false;
+        revert_to_     = nullptr;
+      }
     }
 
     // Each hook below decisively sets or clears active_color_, rather than only setting it - a
@@ -77,7 +87,10 @@ namespace tts
       set_color("\033[31m"); // red - NOSONAR, \o{} is C++23-only
     }
 
-    void test_finished([[maybe_unused]] text const& name, bool passed, bool invalid) override
+    void test_finished([[maybe_unused]] text const&        name,
+                       bool                                passed,
+                       bool                                invalid,
+                       [[maybe_unused]] unsigned long long duration_ns) override
     {
       if(invalid) set_color("\033[33m");     // yellow - NOSONAR, \o{} is C++23-only
       else if(passed) set_color("\033[32m"); // green - NOSONAR, \o{} is C++23-only
@@ -95,6 +108,7 @@ namespace tts
                       [[maybe_unused]] unsigned long long total) override
     {
       using enum outcome;
+      revert_to_ = active_color_; // fall back to this once the segment below is written
       switch(kind)
       {
       case success: set_color("\033[1;32m"); break; // bold green - NOSONAR
@@ -123,5 +137,6 @@ namespace tts
     output_sink* target_;
     char const*  active_color_  = nullptr;
     bool         color_applied_ = false;
+    char const*  revert_to_     = nullptr;
   };
 }

--- a/include/tts/sinks/tap.hpp
+++ b/include/tts/sinks/tap.hpp
@@ -50,7 +50,10 @@ namespace tts
       // Intentionally empty: TAP output is built entirely from test_finished() below.
     }
 
-    void test_finished(text const& name, bool passed, [[maybe_unused]] bool invalid) override
+    void test_finished(text const&                         name,
+                       bool                                passed,
+                       [[maybe_unused]] bool               invalid,
+                       [[maybe_unused]] unsigned long long duration_ns) override
     {
       ++count_;
       body_ += passed ? text {"ok %zu - %s\n", count_, name.data()}

--- a/include/tts/tools/clock.hpp
+++ b/include/tts/tools/clock.hpp
@@ -35,7 +35,8 @@ namespace tts::_
                                            static_cast<double>(freq.QuadPart));
 #else
     struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC, &ts);
+    clock_gettime(CLOCK_MONOTONIC,
+                  &ts); // NOSONAR - the whole point is avoiding <chrono>, see above
     return static_cast<unsigned long long>(ts.tv_sec) * 1'000'000'000ULL +
            static_cast<unsigned long long>(ts.tv_nsec);
 #endif

--- a/include/tts/tools/clock.hpp
+++ b/include/tts/tools/clock.hpp
@@ -17,6 +17,8 @@
 #include <time.h>
 #endif
 
+#include <tts/tools/text.hpp>
+
 namespace tts::_
 {
   // Monotonic timestamp in nanoseconds, for measuring elapsed durations between two calls - never
@@ -40,5 +42,17 @@ namespace tts::_
     return static_cast<unsigned long long>(ts.tv_sec) * 1'000'000'000ULL +
            static_cast<unsigned long long>(ts.tv_nsec);
 #endif
+  }
+
+  // Picks whichever of ns/us/ms/s keeps the displayed value in a readable range, instead of a
+  // fixed unit that reads as "0.000ms" for a trivial test or "15455566.123ms" for a slow suite.
+  // Thresholds sit half a displayed-digit below each power of 1000, so a value that would round
+  // up to e.g. "1000.000 ms" bumps to the next unit ("1.000 s") instead of showing four digits.
+  inline ::tts::text format_duration(double duration_ns)
+  {
+    if(duration_ns < 999.5) return ::tts::text {"%.0f ns", duration_ns};
+    if(duration_ns < 999'999.5) return ::tts::text {"%.3f us", duration_ns / 1'000.0};
+    if(duration_ns < 999'999'500.0) return ::tts::text {"%.3f ms", duration_ns / 1'000'000.0};
+    return ::tts::text {"%.3f s", duration_ns / 1'000'000'000.0};
   }
 }

--- a/include/tts/tools/clock.hpp
+++ b/include/tts/tools/clock.hpp
@@ -37,8 +37,7 @@ namespace tts::_
                                            static_cast<double>(freq.QuadPart));
 #else
     struct timespec ts;
-    clock_gettime(CLOCK_MONOTONIC,
-                  &ts); // NOSONAR - the whole point is avoiding <chrono>, see above
+    clock_gettime(CLOCK_MONOTONIC, &ts); // NOSONAR - avoiding <chrono>, see comment above
     return static_cast<unsigned long long>(ts.tv_sec) * 1'000'000'000ULL +
            static_cast<unsigned long long>(ts.tv_nsec);
 #endif

--- a/include/tts/tools/clock.hpp
+++ b/include/tts/tools/clock.hpp
@@ -1,0 +1,43 @@
+//======================================================================================================================
+//! @file
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//======================================================================================================================
+#pragma once
+
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#include <profileapi.h>
+#else
+#include <time.h>
+#endif
+
+namespace tts::_
+{
+  // Monotonic timestamp in nanoseconds, for measuring elapsed durations between two calls - never
+  // a meaningful absolute point in time on its own. Not std::chrono: measured empirically at
+  // ~0.55-0.6s (5-6x) of extra compile time per translation unit, unacceptable in a header
+  // included by every user's test binary. windows.h with WIN32_LEAN_AND_MEAN/NOMINMAX measured
+  // as free (no significant cost vs. an empty translation unit) with cl.exe.
+  inline unsigned long long now_ns()
+  {
+#if defined(_WIN32)
+    LARGE_INTEGER freq;
+    LARGE_INTEGER count;
+    QueryPerformanceFrequency(&freq);
+    QueryPerformanceCounter(&count);
+    return static_cast<unsigned long long>(static_cast<double>(count.QuadPart) * 1e9 /
+                                           static_cast<double>(freq.QuadPart));
+#else
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return static_cast<unsigned long long>(ts.tv_sec) * 1'000'000'000ULL +
+           static_cast<unsigned long long>(ts.tv_nsec);
+#endif
+  }
+}

--- a/include/tts/tools/output.hpp
+++ b/include/tts/tools/output.hpp
@@ -136,10 +136,11 @@ namespace tts
 
     /// Called once a @ref TTS_CASE / @ref TTS_CASE_TPL / @ref TTS_CASE_WITH has finished
     /// running, always and before its corresponding text (if any - suppressed under -q), with
-    /// its outcome. No-op by default.
-    virtual void test_finished([[maybe_unused]] text const& name,
-                               [[maybe_unused]] bool        passed,
-                               [[maybe_unused]] bool        invalid)
+    /// its outcome and how long it took to run, in nanoseconds. No-op by default.
+    virtual void test_finished([[maybe_unused]] text const&        name,
+                               [[maybe_unused]] bool               passed,
+                               [[maybe_unused]] bool               invalid,
+                               [[maybe_unused]] unsigned long long duration_ns)
     {
       // Intentionally empty: most sinks only care about the formatted text stream.
     }
@@ -345,9 +346,9 @@ namespace tts
     }
 
     /// Notifies the current output_sink that a test has finished running.
-    void test_finished(text const& name, bool passed, bool invalid)
+    void test_finished(text const& name, bool passed, bool invalid, unsigned long long duration_ns)
     {
-      sink_->test_finished(name, passed, invalid);
+      sink_->test_finished(name, passed, invalid, duration_ns);
     }
 
     /// Notifies the current output_sink that the whole suite has finished running.

--- a/test/unit/tests/structured_sink.cpp
+++ b/test/unit/tests/structured_sink.cpp
@@ -46,10 +46,19 @@ namespace
       (void)location;
     }
 
-    void test_finished(tts::text const& name, bool passed, bool invalid) override
+    void test_finished(tts::text const&   name,
+                       bool               passed,
+                       bool               invalid,
+                       unsigned long long duration_ns) override
     {
-      log += tts::text {
-      "FINISHED name=%s passed=%d invalid=%d\n", name.data(), passed ? 1 : 0, invalid ? 1 : 0};
+      // Sane upper bound (under 10s), not an exact value - actual timing is inherently
+      // machine-dependent and would make this test flaky.
+      bool sane  = duration_ns < 10'000'000'000ULL;
+      log       += tts::text {"FINISHED name=%s passed=%d invalid=%d duration_sane=%d\n",
+                        name.data(),
+                        passed ? 1 : 0,
+                        invalid ? 1 : 0,
+                        sane ? 1 : 0};
     }
 
     void suite_finished(unsigned long long fail_count, unsigned long long invalid_count) override
@@ -79,8 +88,9 @@ int main(int argc, char const** argv)
   ok && (strstr(log, "STARTED name=Passing case for structured hooks\n") != nullptr); // NOSONAR
   ok =
   ok &&
-  (strstr(log, "FINISHED name=Passing case for structured hooks passed=1 invalid=0\n") // NOSONAR
-   != nullptr);
+  (strstr(log, // NOSONAR
+          "FINISHED name=Passing case for structured hooks passed=1 invalid=0 duration_sane=1\n") !=
+   nullptr);
 
   ok =
   ok && (strstr(log, "STARTED name=Failing case for structured hooks\n") != nullptr); // NOSONAR
@@ -89,15 +99,17 @@ int main(int argc, char const** argv)
          != nullptr);
   ok =
   ok &&
-  (strstr(log, "FINISHED name=Failing case for structured hooks passed=0 invalid=0\n") // NOSONAR
-   != nullptr);
+  (strstr(log, // NOSONAR
+          "FINISHED name=Failing case for structured hooks passed=0 invalid=0 duration_sane=1\n") !=
+   nullptr);
 
   ok =
   ok && (strstr(log, "STARTED name=Invalid case for structured hooks\n") != nullptr); // NOSONAR
   ok =
   ok &&
-  (strstr(log, "FINISHED name=Invalid case for structured hooks passed=0 invalid=1\n") // NOSONAR
-   != nullptr);
+  (strstr(log, // NOSONAR
+          "FINISHED name=Invalid case for structured hooks passed=0 invalid=1 duration_sane=1\n") !=
+   nullptr);
 
   ok = ok && (strstr(log, "SUITE_FINISHED fails=1 invalids=1\n") != nullptr); // NOSONAR
 


### PR DESCRIPTION
Every test's duration is measured unconditionally via a portable nanosecond clock (clock_gettime on POSIX, QueryPerformanceCounter on Windows - <chrono> was ruled out earlier for its ~5-6x compile-time cost) and passed to output_sink::test_finished(), so sinks can use it regardless of -v. --verbose shows it inline, and Results: gains an always-shown Total Time: summary line. Unblocks #164's TeamCity/JUnit tiers.