### PR TITLE
Fix #187 - Per-test expected-outcome metadata (TTS_XFAIL/TTS_MAYFAIL/TTS_XINVALID)

### DIFF
--- a/include/tts/engine/case.hpp
+++ b/include/tts/engine/case.hpp
@@ -26,11 +26,17 @@ namespace tts::_
         : name(id)
     {
     }
+    capture(tagged_id id) // NOSONAR
+        : name(id.name)
+        , tag(id.tag)
+    {
+    }
     auto operator+(auto body) const
     {
-      return test::acknowledge({name, body});
+      return test::acknowledge({name, body, /*types=*/ {}, tag});
     }
-    char const* name;
+    char const*             name;
+    ::tts::expected_outcome tag = ::tts::expected_outcome::pass;
   };
 
   // Global storage for current type used in a given test
@@ -60,6 +66,11 @@ namespace tts::_
         : name(id)
     {
     }
+    captures(tagged_id id) // NOSONAR
+        : name(id.name)
+        , tag(id.tag)
+    {
+    }
 
     auto operator+(auto body) const
     {
@@ -80,9 +91,11 @@ namespace tts::_
          // Clear the current type
          current_type = text {""};
        },
-       joined_type_names<Types...>()});
+       joined_type_names<Types...>(),
+       tag});
     }
-    char const* name;
+    char const*             name;
+    ::tts::expected_outcome tag = ::tts::expected_outcome::pass;
   };
 
   // Specialisation for types lists
@@ -102,10 +115,16 @@ namespace tts::_
   template<typename... Type, auto... Generators>
   struct test_generators<types<Type...>, Generators...>
   {
-    char const* name;
+    char const*             name;
+    ::tts::expected_outcome tag = ::tts::expected_outcome::pass;
 
     test_generators(char const* id) // NOSONAR
         : name(id)
+    {
+    }
+    test_generators(tagged_id id) // NOSONAR
+        : name(id.name)
+        , tag(id.tag)
     {
     }
 
@@ -129,7 +148,8 @@ namespace tts::_
                                   (process_type<Type>(body), ...);
                                   current_type = text {""};
                                 },
-                                joined_type_names<Type...>()});
+                                joined_type_names<Type...>(),
+                                tg.tag});
     }
   };
 }
@@ -232,6 +252,79 @@ namespace tts::_
   [[maybe_unused]] static bool const TTS_CAT(case_, TTS_FUNCTION) =                                \
   ::tts::_::test_generators<::tts::as_type_list_t<TTS_REMOVE_PARENS(TYPES)>, __VA_ARGS__> {ID}     \
   << [] /**/
+#endif
+
+//======================================================================================================================
+/**
+  @def TTS_XFAIL
+  @brief Tags a @ref TTS_CASE (or @ref TTS_CASE_TPL / @ref TTS_CASE_WITH) ID as expected to fail.
+
+  Wraps the case's ID instead of changing the enclosing macro's signature, so it composes with
+  @ref TTS_CASE, @ref TTS_CASE_TPL and @ref TTS_CASE_WITH unchanged: `TTS_CASE(TTS_XFAIL("..."))`.
+
+  The case is expected to produce at least one failing assertion. If it runs with no failures
+  instead, that mismatch is reported and fails the suite - matching the "X = expected" naming
+  convention already used by other test frameworks (pytest's `xfail`, DejaGnu, Perl's
+  `Test::More`), so it reads the same way to anyone coming from one of those.
+
+  An empty case (no assertion ran at all) does not satisfy `TTS_XFAIL` either - use
+  @ref TTS_XINVALID for that.
+
+  @param ID A literal string describing the scenario intents.
+
+  @see TTS_MAYFAIL
+  @see TTS_XINVALID
+**/
+//======================================================================================================================
+#if defined(TTS_DOXYGEN_INVOKED)
+#define TTS_XFAIL(ID)
+#else
+#define TTS_XFAIL(ID) ::tts::expect_fail(ID)
+#endif
+
+//======================================================================================================================
+/**
+  @def TTS_MAYFAIL
+  @brief Tags a @ref TTS_CASE (or @ref TTS_CASE_TPL / @ref TTS_CASE_WITH) ID as allowed to fail.
+
+  Unlike @ref TTS_XFAIL, nothing specific is expected: the case may pass or fail, either is
+  accepted and neither is reported. Useful for flagging a work-in-progress or a known issue
+  that shouldn't block the suite without pretending to require a specific outcome.
+
+  An empty case is still reported, exactly as for an untagged @ref TTS_CASE - `TTS_MAYFAIL`
+  only relaxes the pass/fail expectation, not the "did anything actually run" one.
+
+  @param ID A literal string describing the scenario intents.
+
+  @see TTS_XFAIL
+  @see TTS_XINVALID
+**/
+//======================================================================================================================
+#if defined(TTS_DOXYGEN_INVOKED)
+#define TTS_MAYFAIL(ID)
+#else
+#define TTS_MAYFAIL(ID) ::tts::may_fail(ID)
+#endif
+
+//======================================================================================================================
+/**
+  @def TTS_XINVALID
+  @brief Tags a @ref TTS_CASE (or @ref TTS_CASE_TPL / @ref TTS_CASE_WITH) ID as expected to be
+empty.
+
+  The case is expected to register no assertion at all. If it runs any assertion instead
+  (passing or failing), that mismatch is reported and fails the suite.
+
+  @param ID A literal string describing the scenario intents.
+
+  @see TTS_XFAIL
+  @see TTS_MAYFAIL
+**/
+//======================================================================================================================
+#if defined(TTS_DOXYGEN_INVOKED)
+#define TTS_XINVALID(ID)
+#else
+#define TTS_XINVALID(ID) ::tts::expect_invalid(ID)
 #endif
 
 //======================================================================================================================

--- a/include/tts/engine/case.hpp
+++ b/include/tts/engine/case.hpp
@@ -274,6 +274,9 @@ namespace tts::_
 
   @see TTS_MAYFAIL
   @see TTS_XINVALID
+
+  @groupheader{Example}
+  @snippet doc/xfail.cpp snippet
 **/
 //======================================================================================================================
 #if defined(TTS_DOXYGEN_INVOKED)
@@ -298,6 +301,9 @@ namespace tts::_
 
   @see TTS_XFAIL
   @see TTS_XINVALID
+
+  @groupheader{Example}
+  @snippet doc/mayfail.cpp snippet
 **/
 //======================================================================================================================
 #if defined(TTS_DOXYGEN_INVOKED)
@@ -319,6 +325,9 @@ empty.
 
   @see TTS_XFAIL
   @see TTS_MAYFAIL
+
+  @groupheader{Example}
+  @snippet doc/xinvalid.cpp snippet
 **/
 //======================================================================================================================
 #if defined(TTS_DOXYGEN_INVOKED)

--- a/include/tts/engine/environment.hpp
+++ b/include/tts/engine/environment.hpp
@@ -41,6 +41,10 @@ namespace tts::_
       test_count++;
       invalid_count++;
     }
+    void unexpected()
+    {
+      unexpected_count++;
+    }
 
     int report(unsigned long long fails, unsigned long long invalids) const
     {
@@ -100,7 +104,11 @@ namespace tts::_
       if(test_count == 0 && !::tts::arguments()("--allow-empty") && !::tts::arguments()("--shard"))
         return 1;
 
-      if(!fails && !invalids) return test_count == success_count ? 0 : 1;
+      // No explicit fails/invalids given: fall back to per-case expected-outcome tracking
+      // (TTS_XFAIL/TTS_MAYFAIL/TTS_XINVALID) instead of the raw success count - for a plain,
+      // untagged suite this is equivalent, since only a case that didn't pass raises
+      // unexpected_count.
+      if(!fails && !invalids) return unexpected_count == 0 ? 0 : 1;
       else return (failure_count == fails && invalid_count == invalids) ? 0 : 1;
     }
 
@@ -109,6 +117,7 @@ namespace tts::_
     unsigned long long failure_count     = 0;
     unsigned long long fatal_count       = 0;
     unsigned long long invalid_count     = 0;
+    unsigned long long unexpected_count  = 0;
     unsigned long long total_duration_ns = 0;
     bool               fail_status       = false;
   };

--- a/include/tts/engine/main.hpp
+++ b/include/tts/engine/main.hpp
@@ -242,13 +242,35 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
       bool invalid                             = (test_count == ::tts::global_runtime.test_count);
       bool passed = !invalid && (failure_count == ::tts::global_runtime.failure_count);
 
+      // What actually happened (invalid/passed above) never changes based on the case's tag -
+      // only whether that actual result is what the case itself declared to expect does.
+      bool matches_expectation = false;
+      using enum ::tts::expected_outcome;
+      switch(t.tag)
+      {
+      case pass: matches_expectation = passed; break;
+      case xfail: matches_expectation = !invalid && !passed; break;
+      case may_fail: matches_expectation = !invalid; break;
+      case xinvalid: matches_expectation = invalid; break;
+      }
+
       if(invalid) ::tts::global_runtime.invalid();
+      if(!matches_expectation) ::tts::global_runtime.unexpected();
 
       ::tts::output().test_finished(::tts::text {t.name}, passed, invalid, duration_ns);
 
       ::tts::text duration_txt = ::tts::_::format_duration(static_cast<double>(duration_ns));
 
-      if(invalid)
+      if(t.tag != pass && !matches_expectation)
+      {
+        if(!::tts::is_quiet())
+          ::tts::output().writeln("TEST: '%s' - ** UNEXPECTED ** (tagged %s) (%s)",
+                                  t.name,
+                                  ::tts::_::tag_name(t.tag),
+                                  duration_txt.data());
+        ::tts::output().flush();
+      }
+      else if(invalid)
       {
         if(!::tts::is_quiet())
         {

--- a/include/tts/engine/test.hpp
+++ b/include/tts/engine/test.hpp
@@ -11,9 +11,48 @@
 #include <tts/tools/callable.hpp>
 #include <tts/tools/text.hpp>
 
+namespace tts
+{
+  //====================================================================================================================
+  /**
+    @brief What a given @ref TTS_CASE is expected to produce.
+
+    Defaults to `pass` for a plain @ref TTS_CASE. Set to anything else by wrapping the case's ID in
+    @ref TTS_XFAIL, @ref TTS_MAYFAIL or @ref TTS_XINVALID.
+  **/
+  //====================================================================================================================
+  enum class expected_outcome
+  {
+    pass,     ///< The case is expected to pass, like a plain untagged @ref TTS_CASE.
+    xfail,    ///< The case is expected to fail - if it passes instead, that's reported.
+    may_fail, ///< The case may pass or fail, either is accepted - only an empty case is reported.
+    xinvalid  ///< The case is expected to be empty (register no assertion at all).
+  };
+}
+
 namespace tts::_
 {
   inline char const* current_test = "";
+
+  // Produced by TTS_XFAIL/TTS_MAYFAIL/TTS_XINVALID, consumed by capture/captures/test_generators's
+  // tagged constructor overload - carries the outcome tag through to test registration without
+  // changing what a case's ID argument itself looks like for the common, untagged case.
+  struct tagged_id
+  {
+    char const*             name;
+    ::tts::expected_outcome tag;
+  };
+
+  inline char const* tag_name(::tts::expected_outcome tag)
+  {
+    switch(tag)
+    {
+    case ::tts::expected_outcome::xfail: return "XFAIL";
+    case ::tts::expected_outcome::may_fail: return "MAYFAIL";
+    case ::tts::expected_outcome::xinvalid: return "XINVALID";
+    default: return "PASS";
+    }
+  }
 
   struct test
   {
@@ -22,11 +61,12 @@ namespace tts::_
       current_test = name;
       behaviour();
     }
-    static inline bool acknowledge(test&& f);
+    static inline bool      acknowledge(test&& f);
 
-    char const*        name;
-    tts::_::callable   behaviour;
-    tts::text          types = {};
+    char const*             name;
+    tts::_::callable        behaviour;
+    tts::text               types = {};
+    ::tts::expected_outcome tag   = ::tts::expected_outcome::pass;
   };
 
   // Global tests suite
@@ -40,5 +80,26 @@ namespace tts::_
   {
     suite().emplace_back(TTS_MOVE(f));
     return true;
+  }
+}
+
+namespace tts
+{
+  /// Tags a @ref TTS_CASE's ID as expected to fail - see @ref TTS_XFAIL.
+  inline _::tagged_id expect_fail(char const* id)
+  {
+    return {id, expected_outcome::xfail};
+  }
+
+  /// Tags a @ref TTS_CASE's ID as allowed to pass or fail - see @ref TTS_MAYFAIL.
+  inline _::tagged_id may_fail(char const* id)
+  {
+    return {id, expected_outcome::may_fail};
+  }
+
+  /// Tags a @ref TTS_CASE's ID as expected to be empty - see @ref TTS_XINVALID.
+  inline _::tagged_id expect_invalid(char const* id)
+  {
+    return {id, expected_outcome::xinvalid};
   }
 }

--- a/include/tts/engine/test.hpp
+++ b/include/tts/engine/test.hpp
@@ -45,13 +45,15 @@ namespace tts::_
 
   inline char const* tag_name(::tts::expected_outcome tag)
   {
+    using enum ::tts::expected_outcome;
     switch(tag)
     {
-    case ::tts::expected_outcome::xfail: return "XFAIL";
-    case ::tts::expected_outcome::may_fail: return "MAYFAIL";
-    case ::tts::expected_outcome::xinvalid: return "XINVALID";
-    default: return "PASS";
+    case pass: return "PASS";
+    case xfail: return "XFAIL";
+    case may_fail: return "MAYFAIL";
+    case xinvalid: return "XINVALID";
     }
+    return ""; // NOSONAR - unreachable, expected_outcome only ever holds one of the 4 cases above
   }
 
   struct test

--- a/test/unit/doc/mayfail.cpp
+++ b/test/unit/doc/mayfail.cpp
@@ -1,0 +1,17 @@
+//==================================================================================================
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+
+//! [snippet]
+#define TTS_MAIN
+#include <tts/tts.hpp>
+
+TTS_CASE(TTS_MAYFAIL("Flaky under load on some CI runners"))
+{
+  TTS_EXPECT(true); // may occasionally fail elsewhere - either outcome is accepted here
+};
+//! [snippet]

--- a/test/unit/doc/mayfail.cpp
+++ b/test/unit/doc/mayfail.cpp
@@ -7,7 +7,7 @@
 //==================================================================================================
 
 //! [snippet]
-#define TTS_MAIN
+#define TTS_MAIN // No need for main()
 #include <tts/tts.hpp>
 
 TTS_CASE(TTS_MAYFAIL("Flaky under load on some CI runners"))

--- a/test/unit/doc/xfail.cpp
+++ b/test/unit/doc/xfail.cpp
@@ -7,7 +7,7 @@
 //==================================================================================================
 
 //! [snippet]
-#define TTS_MAIN
+#define TTS_MAIN // No need for main()
 #include <tts/tts.hpp>
 
 TTS_CASE(TTS_XFAIL("Known, not-yet-fixed rounding bug"))

--- a/test/unit/doc/xfail.cpp
+++ b/test/unit/doc/xfail.cpp
@@ -1,0 +1,17 @@
+//==================================================================================================
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+
+//! [snippet]
+#define TTS_MAIN
+#include <tts/tts.hpp>
+
+TTS_CASE(TTS_XFAIL("Known, not-yet-fixed rounding bug"))
+{
+  TTS_EQUAL(1 + 1, 3); // stands in for the real, currently broken behavior being tracked
+};
+//! [snippet]

--- a/test/unit/doc/xinvalid.cpp
+++ b/test/unit/doc/xinvalid.cpp
@@ -7,7 +7,7 @@
 //==================================================================================================
 
 //! [snippet]
-#define TTS_MAIN
+#define TTS_MAIN // No need for main()
 #include <tts/tts.hpp>
 
 TTS_CASE(TTS_XINVALID("Placeholder for a scenario not written yet"))

--- a/test/unit/doc/xinvalid.cpp
+++ b/test/unit/doc/xinvalid.cpp
@@ -1,0 +1,17 @@
+//==================================================================================================
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+
+//! [snippet]
+#define TTS_MAIN
+#include <tts/tts.hpp>
+
+TTS_CASE(TTS_XINVALID("Placeholder for a scenario not written yet"))
+{
+// Intentionally empty - stays a visible reminder in the suite instead of silently vanishing
+};
+//! [snippet]

--- a/test/unit/tests/expected_outcome.cpp
+++ b/test/unit/tests/expected_outcome.cpp
@@ -1,0 +1,99 @@
+//==================================================================================================
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#define TTS_MAIN
+#include <tts/tts.hpp>
+
+TTS_CASE("expect_fail/may_fail/expect_invalid tag their ID correctly")
+{
+  TTS_EQUAL(::tts::expect_fail("x").tag, ::tts::expected_outcome::xfail);
+  TTS_EQUAL(::tts::may_fail("x").tag, ::tts::expected_outcome::may_fail);
+  TTS_EQUAL(::tts::expect_invalid("x").tag, ::tts::expected_outcome::xinvalid);
+};
+
+namespace
+{
+  ::tts::expected_outcome tag_of(char const* name)
+  {
+    for(auto const& t: ::tts::_::suite())
+      if(::tts::text {t.name} == ::tts::text {name}) return t.tag;
+    return ::tts::expected_outcome::pass;
+  }
+}
+
+TTS_CASE(TTS_XFAIL("xfail-tagged plain case"))
+{
+  TTS_EXPECT(1 == 2); // genuinely expected to fail - matches its own tag
+};
+
+TTS_CASE(TTS_MAYFAIL("mayfail-tagged plain case"))
+{
+  TTS_EXPECT(1 == 2); // tolerated either way
+};
+
+TTS_CASE(TTS_XINVALID("xinvalid-tagged plain case"))
+{
+// genuinely empty - matches its own tag
+};
+
+TTS_CASE_TPL(TTS_XFAIL("xfail-tagged template case"), int, float)
+(auto)
+{
+  TTS_EXPECT(1 == 2);
+};
+
+TTS_CASE("Registered tags are visible on the corresponding tts::_::test entries")
+{
+  TTS_EQUAL(tag_of("xfail-tagged plain case"), ::tts::expected_outcome::xfail);
+  TTS_EQUAL(tag_of("mayfail-tagged plain case"), ::tts::expected_outcome::may_fail);
+  TTS_EQUAL(tag_of("xinvalid-tagged plain case"), ::tts::expected_outcome::xinvalid);
+  TTS_EQUAL(tag_of("xfail-tagged template case"), ::tts::expected_outcome::xfail);
+  TTS_EQUAL(tag_of("Registered tags are visible on the corresponding tts::_::test entries"),
+            ::tts::expected_outcome::pass);
+};
+
+TTS_CASE("report() passes when every case matched its declared tag")
+{
+  ::tts::gathering_sink silence;
+  ::tts::scoped_sink    quiet {silence};
+
+  ::tts::_::env         local;
+  local.test_count       = 3;
+  local.success_count    = 2;
+  local.failure_count    = 1;
+  local.unexpected_count = 0; // the one failure matched its own tag (e.g. TTS_XFAIL)
+
+  TTS_EQUAL(local.report(0, 0), 0);
+};
+
+TTS_CASE("report() fails when at least one case's outcome didn't match its tag")
+{
+  ::tts::gathering_sink silence;
+  ::tts::scoped_sink    quiet {silence};
+
+  ::tts::_::env         local;
+  local.test_count       = 3;
+  local.success_count    = 3;
+  local.unexpected_count = 1; // e.g. a TTS_XFAIL case that unexpectedly passed
+
+  TTS_EQUAL(local.report(0, 0), 1);
+};
+
+TTS_CASE("The legacy two-argument report(fails, invalids) form ignores unexpected_count")
+{
+  ::tts::gathering_sink silence;
+  ::tts::scoped_sink    quiet {silence};
+
+  ::tts::_::env         local;
+  local.test_count       = 3;
+  local.failure_count    = 2;
+  local.invalid_count    = 1;
+  local.unexpected_count = 5; // irrelevant on the explicit fails/invalids path
+
+  TTS_EQUAL(local.report(2, 1), 0);
+  TTS_EQUAL(local.report(1, 1), 1);
+};


### PR DESCRIPTION
Lets a TTS_CASE (or TTS_CASE_TPL/TTS_CASE_WITH) declare its own expected outcome via TTS_XFAIL/TTS_MAYFAIL/TTS_XINVALID, so the tag travels with the case itself instead of relying on an external tts::report(fails, invalids) aggregate count - a shard can then validate the tests it actually ran without needing to know the whole suite's total up front.

Display stays literal on purpose: an expected failure still prints its normal failure lines rather than being relabelled; a case whose actual result doesn't match its declared tag gets a dedicated "** UNEXPECTED **" line instead.