### PR TITLE
Run precommit/standalone/sanitizers in parallel, gate the compiler matrix behind them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ concurrency:
 
 jobs:
   ##################################################################################################
-  ## Preserve pre-commit checks
+  ## Fast gate: pre-commit checks, standalone generation and sanitizers all start together with no
+  ## interdependency - only once all three pass does the (much heavier) compiler matrix start below.
   ##################################################################################################
   precommit:
     runs-on: ubuntu-latest
@@ -31,43 +32,11 @@ jobs:
       - name: Run pre-commit checks
         run: pre-commit run --all-files --show-diff-on-failure --color=always
 
-  ##################################################################################################
-  ## Unit Tests
-  ##################################################################################################
-  linux-tests:
-    name: Linux
-    needs: precommit
-    uses: ./.github/workflows/linux.yml
-
-  ##################################################################################################
-  ## Sanitizers (ASan+UBSan) - runs after the normal Linux matrix (tests + MemCheck) has passed
-  ##################################################################################################
-  sanitizer-tests:
-    name: Sanitizers
-    needs: linux-tests
-    uses: ./.github/workflows/sanitizers.yml
-
-  macos-tests:
-    name: MacOS
-    needs: precommit
-    uses: ./.github/workflows/macos.yml
-
-  windows-tests:
-    name: Windows
-    needs: precommit
-    uses: ./.github/workflows/windows.yml
-
-  nvidia-tests:
-    name: Nvidia
-    needs: precommit
-    uses: ./.github/workflows/nvidia.yml
-
   ##======================================================================================================================
   ## Ensure Standalone is viable
   ##======================================================================================================================
   standalone-generation:
     name: Standalone Generation
-    needs: [precommit]
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/jfalcou/compilers:v10
@@ -84,3 +53,33 @@ jobs:
         run: |
           cd build
           g++ -std=c++20 -S -I. ../test/integration/main.cpp -DTTS_STANDALONE
+
+  ##################################################################################################
+  ## Sanitizers (ASan+UBSan)
+  ##################################################################################################
+  sanitizer-tests:
+    name: Sanitizers
+    uses: ./.github/workflows/sanitizers.yml
+
+  ##################################################################################################
+  ## Unit Tests - the full compiler matrix, gated behind the fast checks above all passing
+  ##################################################################################################
+  linux-tests:
+    name: Linux
+    needs: [precommit, standalone-generation, sanitizer-tests]
+    uses: ./.github/workflows/linux.yml
+
+  macos-tests:
+    name: MacOS
+    needs: [precommit, standalone-generation, sanitizer-tests]
+    uses: ./.github/workflows/macos.yml
+
+  windows-tests:
+    name: Windows
+    needs: [precommit, standalone-generation, sanitizer-tests]
+    uses: ./.github/workflows/windows.yml
+
+  nvidia-tests:
+    name: Nvidia
+    needs: [precommit, standalone-generation, sanitizer-tests]
+    uses: ./.github/workflows/nvidia.yml


### PR DESCRIPTION
precommit, standalone generation and sanitizers no longer form a chain (sanitizers used to wait on the full Linux matrix) - all three now start together with no interdependency. The Linux/MacOS/Windows/Nvidia compiler matrices only start once all three pass, keeping their own internal breakdown unchanged.