### PR TITLE
Fix TTS_FATAL silently returning exit code 0 (regression from #187)

### DIFF
--- a/include/tts/engine/main.hpp
+++ b/include/tts/engine/main.hpp
@@ -302,6 +302,12 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
   }
   catch(::tts::_::fatal_signal&)
   {
+    // The aborted case's own tag was never compared against its (nonexistent) actual outcome -
+    // t() never returned, so the driver loop's per-case bookkeeping above never ran for it. A
+    // fatal abort is always unexpected for the suite regardless of that case's tag, so count it
+    // here instead - otherwise a suite that aborts via TTS_FATAL could still report success.
+    ::tts::global_runtime.unexpected();
+
     ::tts::output().suite_aborted();
 
     if(!::tts::is_quiet())

--- a/test/unit/tests/suite_aborted.cpp
+++ b/test/unit/tests/suite_aborted.cpp
@@ -42,5 +42,12 @@ int main(int argc, char const** argv)
     suite_aborted_main(argc, argv);
   }
 
-  return sink.aborted ? 0 : 1;
+  bool ok = sink.aborted;
+
+  // A TTS_FATAL abort must make the implicit tts::report(0, 0) path (what TTS_MAIN calls
+  // automatically) reflect the failure - the aborted case's own bookkeeping never gets to run,
+  // so the driver's fatal_signal handler needs its own explicit accounting for this.
+  ok = ok && (::tts::report(0, 0) == 1);
+
+  return ok ? 0 : 1;
 }


### PR DESCRIPTION
tts::report()'s implicit fails=invalids=0 path now checks unexpected_count instead of the raw success count, but a fatal abort throws out of t() before the driver loop's per-case bookkeeping runs - unexpected_count never gets incremented for the aborted case, so a suite that hits TTS_FATAL could still report success. Fixed by counting the abort itself in the catch block, and extended suite_aborted.cpp to actually check tts::report()'s return value, which is what would have caught this the first time.