### PR TITLE
Fix #164 (3/N) - Add tts::json_sink, wire up --sink=json

### DIFF
--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -38,4 +38,4 @@ runs:
       env:
         PRESET: ${{ inputs.preset }}
         CONFIG: ${{ inputs.config }}
-      run: ctest --test-dir "build/$PRESET" --preset "$PRESET" --build-config "$CONFIG" -T MemCheck -j 2
+      run: ctest --test-dir "build/$PRESET" --preset "$PRESET" --build-config "$CONFIG" -T MemCheck -j 2 --output-on-failure

--- a/.github/actions/test/action.yml
+++ b/.github/actions/test/action.yml
@@ -28,7 +28,7 @@ runs:
       env:
         PRESET: ${{ inputs.preset }}
         CONFIG: ${{ inputs.config }}
-      run: ctest --preset "$PRESET" --build-config "$CONFIG" -j 2
+      run: ctest --preset "$PRESET" --build-config "$CONFIG" -j 2 --output-on-failure
 
     # MemCheck puts ctest in a mode that is not compatible with how presets are
     # currently made. This is a workaround

--- a/doc/cli.hpp
+++ b/doc/cli.hpp
@@ -65,7 +65,7 @@
   `--allow-empty`   | Do not fail when the test suite registered zero test. `./my_test --allow-empty`
   `--capture=path`  | Capture this run's output and write it to `path` instead of stdout. `./my_test --capture=report.txt`
   `--shard=i/n`     | Only run the tests in shard `i` of `n` (`0 <= i < n`). `./my_test --shard=1/3`
-  `--sink=name`     | Format output as `name` (`colored`, `tap`, or `diagnostics`) - see @ref output-sinks. `./my_test --sink=tap`
+  `--sink=name`     | Format output as `name` (`colored`, `tap`, `diagnostics`, or `json`) - see @ref output-sinks. `./my_test --sink=tap`
 
   @note `--shard=i/n` partitions tests by registration index, round-robin (test at index `k`
   belongs to shard `k % n`), not by contiguous blocks - this keeps shards balanced even when

--- a/doc/sinks.hpp
+++ b/doc/sinks.hpp
@@ -14,7 +14,7 @@
   `include/tts/sinks/`, already available through `#include <tts/tts.hpp>` with no extra include
   needed.
 
-  All three draw from @ref tts::output_sink's structured hooks (`test_started()`,
+  All four draw from @ref tts::output_sink's structured hooks (`test_started()`,
   `assertion_failed()`, `test_finished()`, `suite_finished()`, `suite_metric()`,
   `suite_aborted()`) rather than by parsing the text `tts::stdout_sink` prints, so they stay
   correct regardless of `-v`/`-q`. None of them currently reflect @ref TTS_CASE_TPL's per-type
@@ -22,17 +22,17 @@
   hook.
 
   @note On a plain @ref TTS_MAIN binary (no custom driver), the `--sink=name` CLI flag installs
-  any of the three below without writing any C++ at all - `--sink=colored`, `--sink=tap`, or
-  `--sink=diagnostics`. It composes with `--capture=path`: `--sink=tap --capture=report.tap`
-  writes TAP-formatted output to the file instead of stdout. Like `--shard`, it's a no-op for
-  binaries using a @ref TTS_CUSTOM_DRIVER_FUNCTION, which already manages its own sink - see
-  @ref cli for the full flag reference.
+  any of the four below without writing any C++ at all - `--sink=colored`, `--sink=tap`,
+  `--sink=diagnostics`, or `--sink=json`. It composes with `--capture=path`:
+  `--sink=tap --capture=report.tap` writes TAP-formatted output to the file instead of stdout.
+  Like `--shard`, it's a no-op for binaries using a @ref TTS_CUSTOM_DRIVER_FUNCTION, which
+  already manages its own sink - see @ref cli for the full flag reference.
 
   # Simple Format Sinks
 
-  Each of these produces plain, line-oriented text - as opposed to a hypothetical structured-
-  format sink (JSON, JUnit XML, ...), which would need to assemble a single well-formed document
-  with its own schema instead of just lines of text.
+  Each of these produces plain, line-oriented text - as opposed to a structured-format sink like
+  @ref tts::json_sink below, which assembles a single well-formed document with its own schema
+  instead of just lines of text.
 
   ## %tts::colorized_sink
 
@@ -118,6 +118,46 @@
   @code{sh}
   expect.cpp:15: error: Expression: 1 == 2 evaluates to false.
     [X] [expect.cpp:15] : ** FAILURE ** : Expression: 1 == 2 evaluates to false.
+  @endcode
+
+  # Structured Format Sinks
+
+  Unlike the simple sinks above, this one assembles its output into a single well-formed
+  document with its own schema instead of printing independent lines - so it only ever produces
+  output once the whole run has finished, via `dump()` or `finish()`, never incrementally.
+
+  ## %tts::json_sink
+
+  Accumulates one JSON object per @ref TTS_CASE (`name`, `status`, `duration_ns`, and any
+  failing/fatal assertions gathered while it ran) from `test_finished()` and
+  `assertion_failed()`, plus a `summary` counting passed/failed/invalid cases - counted
+  directly as cases finish, not from the suite's raw assertion totals, so the number of entries
+  in `tests` always matches `summary.total`. No JSON library involved: escaping is hand-rolled
+  in `tts::_::json_escape()`, in keeping with @ref compile-time.
+
+  @code{cpp}
+  tts::json_sink json;
+  tts::output().sink(json);
+
+  // ... run the test suite ...
+
+  json.dump(); // stream the JSON report to stdout
+  @endcode
+
+  Or, without a custom driver: `./my_test --sink=json`.
+
+  Given a suite with one passing and one failing case, `json.dump()` prints (reformatted here
+  for readability - the actual output is a single line):
+
+  @code{json}
+  {
+    "tests": [
+      {"name": "Check that expectation can be met", "status": "passed", "duration_ns": 996, "failures": []},
+      {"name": "Check that expectation fails", "status": "failed", "duration_ns": 8145,
+       "failures": [{"location": "expect.cpp:15", "message": "Expression: 1 == 2 evaluates to false.", "fatal": false}]}
+    ],
+    "summary": {"total": 2, "passed": 1, "failed": 1, "invalid": 0, "duration_ns": 9141}
+  }
   @endcode
 **/
 //==================================================================================================

--- a/doc/sinks.hpp
+++ b/doc/sinks.hpp
@@ -21,6 +21,25 @@
   breakdown or @ref TTS_WHEN / @ref TTS_AND_THEN sub-scenarios, since those don't have their own
   hook.
 
+  Every "Example" below runs this same sample suite - one passing case, one invalid (empty)
+  case, and one failing case:
+
+  @code{cpp}
+  TTS_CASE("Check that expectation can be met")
+  {
+    TTS_EXPECT(1 == 1);
+  };
+
+  TTS_CASE("Check invalid detection")
+  {
+  };
+
+  TTS_CASE("Check that expectation fails")
+  {
+    TTS_EXPECT(1 == 2);
+  };
+  @endcode
+
   @note On a plain @ref TTS_MAIN binary (no custom driver), the `--sink=name` CLI flag installs
   any of the four below without writing any C++ at all - `--sink=colored`, `--sink=tap`,
   `--sink=diagnostics`, or `--sink=json`. It composes with `--capture=path`:
@@ -36,11 +55,15 @@
 
   ## %tts::colorized_sink
 
+  ### Effect
+
   Wraps a target sink (`tts::output_handler::default_sink()` by default), coloring pass/fail/
   invalid lines and the `Results: ...` summary with ANSI escapes - forwarding everything else
   unchanged. Opt-in: not every terminal or CI log renders ANSI escapes usefully, and on Windows
   it additionally depends on the host console having Virtual Terminal Processing enabled (most
   modern terminals already do).
+
+  ### Manual Usage
 
   @code{cpp}
   tts::colorized_sink colorized;
@@ -49,9 +72,13 @@
   // ... run the test suite ...
   @endcode
 
-  Or, without a custom driver: `./my_test --sink=colored`.
+  ### CLI Flag
 
-  A run with one passing, one invalid and one failing case then looks like this:
+  `./my_test --sink=colored`
+
+  ### Example
+
+  Running the sample suite above then looks like this:
 
   @htmlonly
   <pre style="background-color:var(--fragment-background);color:var(--fragment-foreground);
@@ -68,11 +95,15 @@
 
   ## %tts::tap_sink
 
+  ### Effect
+
   [TAP](https://testanything.org/) (Test Anything Protocol) is a simple, language-agnostic text
   format for reporting test results, understood by many CI dashboards and test harnesses.
   `tts::tap_sink` listens to `test_finished()` and accumulates one `ok N - name` /
   `not ok N - name` line per @ref TTS_CASE, then `dump()` streams them out preceded by a leading
   `1..N` plan line.
+
+  ### Manual Usage
 
   @code{cpp}
   tts::tap_sink tap;
@@ -83,26 +114,34 @@
   tap.dump(); // stream the TAP-formatted report to stdout
   @endcode
 
-  Or, without a custom driver: `./my_test --sink=tap` - `dump()` then happens automatically once
-  the run finishes.
+  ### CLI Flag
 
-  Given a suite with one passing and one failing case, `tap.dump()` prints:
+  `./my_test --sink=tap` - `dump()` then happens automatically once the run finishes.
+
+  ### Example
+
+  Running the sample suite above, `tap.dump()` prints - note that TAP has no third state, so
+  the invalid case comes out indistinguishable from a genuine failure:
 
   @code{sh}
-  1..2
+  1..3
   ok 1 - Check that expectation can be met
-  not ok 2 - Check that expectation fails
+  not ok 2 - Check invalid detection
+  not ok 3 - Check that expectation fails
   @endcode
 
   ## %tts::diagnostics_sink
+
+  ### Effect
 
   Wraps a target sink, forwarding every message unchanged, and additionally prints one
   `path:line: error: message` / `path:line: fatal error: message` line per failing/fatal
   assertion, so editors/IDEs with a GCC/Clang-style problem matcher (VS Code's C/C++ extension
   provides `$gcc`, vim has quickfix, ...) can jump straight to it. `assertion_failed()` fires
-  before its corresponding
-  text, so the diagnostic line prints first; it still fires under `-q`, when that raw line is
-  itself suppressed.
+  before its corresponding text, so the diagnostic line prints first; it still fires under `-q`,
+  when that raw line is itself suppressed.
+
+  ### Manual Usage
 
   @code{cpp}
   tts::diagnostics_sink diagnostics;
@@ -111,9 +150,15 @@
   // ... run the test suite ...
   @endcode
 
-  Or, without a custom driver: `./my_test --sink=diagnostics`.
+  ### CLI Flag
 
-  A failing @ref TTS_CASE then prints the diagnostic line, immediately followed by its usual one:
+  `./my_test --sink=diagnostics`
+
+  ### Example
+
+  Running the sample suite above, the failing case prints the diagnostic line, immediately
+  followed by its usual one - the passing and invalid cases are unaffected, since neither
+  triggers `assertion_failed()`:
 
   @code{sh}
   expect.cpp:15: error: Expression: 1 == 2 evaluates to false.
@@ -127,6 +172,8 @@
   output once the whole run has finished, via `dump()` or `finish()`, never incrementally.
 
   ## %tts::json_sink
+
+  ### Effect
 
   Accumulates one JSON object per @ref TTS_CASE from `test_finished()` and `assertion_failed()`,
   plus a `summary` counting passed/failed/invalid cases - counted directly as cases finish, not
@@ -177,6 +224,8 @@
   behave for the same reason: the driver loop's per-case bookkeeping only runs for a case that
   returns normally.
 
+  ### Manual Usage
+
   @code{cpp}
   tts::json_sink json;
   tts::output().sink(json);
@@ -186,19 +235,50 @@
   json.dump(); // stream the JSON report to stdout
   @endcode
 
-  Or, without a custom driver: `./my_test --sink=json`.
+  ### CLI Flag
 
-  Given a suite with one passing and one failing case, `json.dump()` prints (reformatted here
-  for readability - the actual output is a single line):
+  `./my_test --sink=json`
+
+  ### Example
+
+  Running the sample suite above via `--sink=json` produces (pretty-printed here for
+  readability):
 
   @code{json}
   {
     "tests": [
-      {"name": "Check that expectation can be met", "status": "passed", "duration_ns": 996, "failures": []},
-      {"name": "Check that expectation fails", "status": "failed", "duration_ns": 8145,
-       "failures": [{"location": "expect.cpp:15", "message": "Expression: 1 == 2 evaluates to false.", "fatal": false}]}
+      {
+        "name": "Check that expectation can be met",
+        "status": "passed",
+        "duration_ns": 864,
+        "failures": []
+      },
+      {
+        "name": "Check invalid detection",
+        "status": "invalid",
+        "duration_ns": 68,
+        "failures": []
+      },
+      {
+        "name": "Check that expectation fails",
+        "status": "failed",
+        "duration_ns": 8110,
+        "failures": [
+          {
+            "location": "expect.cpp:15",
+            "message": "Expression: 1 == 2 evaluates to false.",
+            "fatal": false
+          }
+        ]
+      }
     ],
-    "summary": {"total": 2, "passed": 1, "failed": 1, "invalid": 0, "duration_ns": 9141}
+    "summary": {
+      "total": 3,
+      "passed": 1,
+      "failed": 1,
+      "invalid": 1,
+      "duration_ns": 9042
+    }
   }
   @endcode
 **/

--- a/doc/sinks.hpp
+++ b/doc/sinks.hpp
@@ -128,12 +128,54 @@
 
   ## %tts::json_sink
 
-  Accumulates one JSON object per @ref TTS_CASE (`name`, `status`, `duration_ns`, and any
-  failing/fatal assertions gathered while it ran) from `test_finished()` and
-  `assertion_failed()`, plus a `summary` counting passed/failed/invalid cases - counted
-  directly as cases finish, not from the suite's raw assertion totals, so the number of entries
-  in `tests` always matches `summary.total`. No JSON library involved: escaping is hand-rolled
-  in `tts::_::json_escape()`, in keeping with @ref compile-time.
+  Accumulates one JSON object per @ref TTS_CASE from `test_finished()` and `assertion_failed()`,
+  plus a `summary` counting passed/failed/invalid cases - counted directly as cases finish, not
+  from the suite's raw assertion totals, so the number of entries in `tests` always matches
+  `summary.total`. No JSON library involved: escaping is hand-rolled in `tts::_::json_escape()`,
+  in keeping with @ref compile-time.
+
+  ### Schema
+
+  The document is a single object with two fields:
+
+  Field      | Type            | Description
+  ---------- | --------------- | -----------------------------------------------------------------
+  `tests`    | array of object | One entry per @ref TTS_CASE that finished running, in run order.
+  `summary`  | object          | Aggregate counts over every entry in `tests`.
+
+  Each entry in `tests`:
+
+  Field          | Type            | Description
+  -------------- | --------------- | -------------------------------------------------------------
+  `name`         | string          | The case's ID, exactly as given to @ref TTS_CASE.
+  `status`       | string          | One of `"passed"`, `"failed"`, `"invalid"` (registered no assertion at all).
+  `duration_ns`  | integer         | Wall-clock time the case took to run, in nanoseconds.
+  `failures`     | array of object | One entry per failing/fatal assertion. Empty unless `status` is `"failed"`.
+
+  Each entry in a `failures` array:
+
+  Field       | Type    | Description
+  ----------- | ------- | ------------------------------------------------------------------------
+  `location`  | string  | `path:line` of the assertion, as reported in the human-readable output.
+  `message`   | string  | The assertion's failure message.
+  `fatal`     | boolean | `true` if this came from @ref TTS_FATAL (which then aborts the whole suite - see `summary` note below).
+
+  `summary`:
+
+  Field          | Type    | Description
+  -------------- | ------- | -------------------------------------------------------------------
+  `total`        | integer | Number of entries in `tests` (`passed` + `failed` + `invalid`).
+  `passed`       | integer | Number of cases with `status: "passed"`.
+  `failed`       | integer | Number of cases with `status: "failed"`.
+  `invalid`      | integer | Number of cases with `status: "invalid"`.
+  `duration_ns`  | integer | Sum of every case's `duration_ns`.
+
+  @note A @ref TTS_FATAL assertion aborts the whole suite immediately - the case it happened in
+  never finishes running, so it never reaches `test_finished()` and does **not** appear in
+  `tests` at all, not even as a `"failed"` entry. `summary.total` then undercounts the suite's
+  actual registered case count. This mirrors how @ref tts::tap_sink and the plain text output
+  behave for the same reason: the driver loop's per-case bookkeeping only runs for a case that
+  returns normally.
 
   @code{cpp}
   tts::json_sink json;

--- a/doc/sinks.hpp
+++ b/doc/sinks.hpp
@@ -203,9 +203,16 @@
 
   Field       | Type    | Description
   ----------- | ------- | ------------------------------------------------------------------------
-  `location`  | string  | `path:line` of the assertion, as reported in the human-readable output.
+  `location`  | object  | Where the assertion is, split into `file`/`line` (see below).
   `message`   | string  | The assertion's failure message.
   `fatal`     | boolean | `true` if this came from @ref TTS_FATAL (which then aborts the whole suite - see `summary` note below).
+
+  `location`:
+
+  Field   | Type    | Description
+  ------- | ------- | ----------------------------------------------------------------------------
+  `file`  | string  | Source file name, as reported in the human-readable output (basename only).
+  `line`  | integer | Line number within `file`.
 
   `summary`:
 
@@ -250,7 +257,7 @@
       {
         "name": "Check that expectation can be met",
         "status": "passed",
-        "duration_ns": 864,
+        "duration_ns": 917,
         "failures": []
       },
       {
@@ -262,10 +269,13 @@
       {
         "name": "Check that expectation fails",
         "status": "failed",
-        "duration_ns": 8110,
+        "duration_ns": 11030,
         "failures": [
           {
-            "location": "expect.cpp:15",
+            "location": {
+              "file": "expect.cpp",
+              "line": 15
+            },
             "message": "Expression: 1 == 2 evaluates to false.",
             "fatal": false
           }
@@ -277,7 +287,7 @@
       "passed": 1,
       "failed": 1,
       "invalid": 1,
-      "duration_ns": 9042
+      "duration_ns": 12015
     }
   }
   @endcode

--- a/include/tts/engine/main.hpp
+++ b/include/tts/engine/main.hpp
@@ -193,6 +193,7 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
   ::tts::colorized_sink   colorized_candidate {capture_target};
   ::tts::tap_sink         tap_candidate {capture_target};
   ::tts::diagnostics_sink diagnostics_candidate {capture_target};
+  ::tts::json_sink        json_candidate {capture_target};
 
   // Neither flag given: leave whatever sink the caller already installed alone, exactly as
   // before --sink existed - only touch output().sink() when there's an actual reason to.
@@ -200,6 +201,7 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
   else if(sink_name == "colored") ::tts::output().sink(colorized_candidate);
   else if(sink_name == "tap") ::tts::output().sink(tap_candidate);
   else if(sink_name == "diagnostics") ::tts::output().sink(diagnostics_candidate);
+  else if(sink_name == "json") ::tts::output().sink(json_candidate);
 
   auto        nb_tests   = shard.count(::tts::_::suite().size());
   std::size_t done_tests = 0;

--- a/include/tts/engine/sink_selection.hpp
+++ b/include/tts/engine/sink_selection.hpp
@@ -15,7 +15,7 @@ namespace tts::_
 {
   // Every accepted --sink=name value - also drives the "expected one of: ..." error message
   // below, so adding a new sink here is the only place that needs updating.
-  inline constexpr std::array<char const*, 3> sink_names {"colored", "tap", "diagnostics"};
+  inline constexpr std::array<char const*, 4> sink_names {"colored", "tap", "diagnostics", "json"};
 
   // Validates --sink=name (read from the current tts::arguments()). ok is set to false for an
   // unknown, non-empty name, in which case the returned text is ready to print as an error.

--- a/include/tts/sinks/json.hpp
+++ b/include/tts/sinks/json.hpp
@@ -81,16 +81,25 @@ namespace tts
 
     void assertion_failed(text const& location, text const& message, bool fatal) override
     {
-      // location is already "[file:line]" (see tts::_::source_location) - strip the brackets.
-      char const* loc = location.data();
-      std::size_t len = strlen(loc); // NOSONAR - loc always comes from a well-formed tts::text
+      // location is "[file:line]" (see tts::_::source_location) - strip the brackets, then split
+      // file from line so consumers get a real integer instead of a string to parse themselves.
+      char const* loc      = location.data();
+      std::size_t len      = strlen(loc); // NOSONAR - loc always comes from a well-formed tts::text
+      text        stripped = text {"%.*s", static_cast<int>(len - 2), loc + 1};
+
+      char const* colon    = strrchr(stripped.data(), ':'); // NOSONAR - stripped always has one
+      text        file =
+      colon ? text {"%.*s", static_cast<int>(colon - stripped.data()), stripped.data()} : stripped;
+      int line = 0;
+      if(colon) sscanf(colon + 1, "%d", &line); // NOSONAR - colon+1 is always digits here
 
       if(!current_failures_.is_empty()) current_failures_ += ",";
-      current_failures_ +=
-      text {"{\"location\":\"%s\",\"message\":\"%s\",\"fatal\":%s}",
-            _::json_escape(text {"%.*s", static_cast<int>(len - 2), loc + 1}).data(),
-            _::json_escape(message).data(),
-            fatal ? "true" : "false"};
+      current_failures_ += text {"{\"location\":{\"file\":\"%s\",\"line\":%d},\"message\":\"%s\","
+                                 "\"fatal\":%s}",
+                                 _::json_escape(file).data(),
+                                 line,
+                                 _::json_escape(message).data(),
+                                 fatal ? "true" : "false"};
     }
 
     void test_finished(text const&        name,

--- a/include/tts/sinks/json.hpp
+++ b/include/tts/sinks/json.hpp
@@ -1,0 +1,171 @@
+//======================================================================================================================
+//! @file
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//======================================================================================================================
+#pragma once
+
+#include <tts/tools/output.hpp>
+
+namespace tts::_
+{
+  // Escapes t for embedding in a JSON string literal - test names and failure messages are
+  // arbitrary user text, so this is the only thing standing between them and invalid JSON.
+  inline ::tts::text json_escape(::tts::text const& t)
+  {
+    ::tts::text out;
+    for(char c: t)
+    {
+      switch(c)
+      {
+      case '"': out += "\\\""; break;
+      case '\\': out += "\\\\"; break;
+      case '\n': out += "\\n"; break;
+      case '\r': out += "\\r"; break;
+      case '\t': out += "\\t"; break;
+      default:
+        if(static_cast<unsigned char>(c) < 0x20)
+          out += ::tts::text {"\\u%04x", static_cast<unsigned>(static_cast<unsigned char>(c))};
+        else out += ::tts::text {"%c", c};
+        break;
+      }
+    }
+    return out;
+  }
+}
+
+namespace tts
+{
+  //====================================================================================================================
+  /**
+    @ingroup tools-sinks
+    @public
+    @brief output_sink rendering the run as a single structured JSON document.
+
+    Built from @ref output_sink's structured hooks rather than by parsing the human-readable text
+    @ref tts::stdout_sink prints, so it stays correct regardless of `-v`/`-q`. Every @ref TTS_CASE
+    becomes one entry in a `"tests"` array (name, status, duration in nanoseconds, and any
+    failing/fatal assertions gathered while it ran), summarized by a `"summary"` object counting
+    passed/failed/invalid cases - counted from `test_finished()` directly, not from the suite's
+    raw assertion totals, so `tests.length` always matches `summary.total`. Rendered by `dump()`,
+    or automatically via `finish()`, to the target given at construction
+    (`tts::output_handler::default_sink()` by default). It does not (currently) reflect
+    @ref TTS_CASE_TPL's per-type breakdown or @ref TTS_WHEN / @ref TTS_AND_THEN sub-scenarios,
+    since those don't have their own hook - only the enclosing @ref TTS_CASE does.
+
+    @groupheader{Example}
+    @code
+    tts::json_sink json;
+    tts::output().sink(json);
+
+    // ... run the test suite ...
+
+    json.dump(); // stream the JSON report to stdout
+    @endcode
+  **/
+  //====================================================================================================================
+  struct json_sink : output_sink
+  {
+    explicit json_sink(output_sink& target = output_handler::default_sink())
+        : target_(&target)
+    {
+    }
+
+    void write(text const&) override
+    {
+      // Intentionally empty: the JSON report is built entirely from the structured hooks below.
+    }
+
+    void assertion_failed(text const& location, text const& message, bool fatal) override
+    {
+      // location is already "[file:line]" (see tts::_::source_location) - strip the brackets.
+      char const* loc = location.data();
+      std::size_t len = strlen(loc); // NOSONAR - loc always comes from a well-formed tts::text
+
+      if(!current_failures_.is_empty()) current_failures_ += ",";
+      current_failures_ +=
+      text {"{\"location\":\"%s\",\"message\":\"%s\",\"fatal\":%s}",
+            _::json_escape(text {"%.*s", static_cast<int>(len - 2), loc + 1}).data(),
+            _::json_escape(message).data(),
+            fatal ? "true" : "false"};
+    }
+
+    void test_finished(text const&        name,
+                       bool               passed,
+                       bool               invalid,
+                       unsigned long long duration_ns) override
+    {
+      char const* status = invalid ? "invalid" : passed ? "passed" : "failed";
+      if(invalid) ++invalid_count_;
+      else if(passed) ++passed_count_;
+      else ++failed_count_;
+      total_duration_ns_ += duration_ns;
+
+      if(!body_.is_empty()) body_ += ",";
+      body_ += text {"{\"name\":\"%s\",\"status\":\"%s\",\"duration_ns\":%llu,\"failures\":[%s]}",
+                     _::json_escape(name).data(),
+                     status,
+                     duration_ns,
+                     current_failures_.data()};
+
+      current_failures_ = text {};
+    }
+
+    /// Renders everything gathered so far as a single JSON document.
+    text render() const
+    {
+      unsigned long long total = passed_count_ + failed_count_ + invalid_count_;
+      return text {"{\"tests\":[%s],\"summary\":{\"total\":%llu,\"passed\":%llu,\"failed\":%llu,"
+                   "\"invalid\":%llu,\"duration_ns\":%llu}}",
+                   body_.data(),
+                   total,
+                   passed_count_,
+                   failed_count_,
+                   invalid_count_,
+                   total_duration_ns_};
+    }
+
+    /// Forwards the JSON-rendered report to target, then clears the gathered results.
+    void dump(output_sink& target)
+    {
+      target.write(render());
+      clear();
+    }
+
+    /// Streams the JSON-rendered report to `stdout`, then clears the gathered results.
+    void dump()
+    {
+      stdout_sink target;
+      dump(target);
+    }
+
+    /// Discards everything gathered so far.
+    void clear()
+    {
+      body_              = text {};
+      current_failures_  = text {};
+      passed_count_      = 0;
+      failed_count_      = 0;
+      invalid_count_     = 0;
+      total_duration_ns_ = 0;
+    }
+
+    /// Dumps the JSON-rendered report to the target given at construction.
+    void finish() override
+    {
+      dump(*target_);
+    }
+
+  private:
+    output_sink*       target_;
+    text               body_;
+    text               current_failures_;
+    unsigned long long passed_count_      = 0;
+    unsigned long long failed_count_      = 0;
+    unsigned long long invalid_count_     = 0;
+    unsigned long long total_duration_ns_ = 0;
+  };
+}

--- a/include/tts/sinks/json.hpp
+++ b/include/tts/sinks/json.hpp
@@ -10,6 +10,9 @@
 
 #include <tts/tools/output.hpp>
 
+TTS_DISABLE_WARNING_PUSH
+TTS_DISABLE_WARNING_CRT_SECURE
+
 namespace tts::_
 {
   // Escapes t for embedding in a JSON string literal - test names and failure messages are
@@ -21,8 +24,8 @@ namespace tts::_
     {
       switch(c)
       {
-      case '"': out += "\\\""; break;
-      case '\\': out += "\\\\"; break;
+      case '"': out += R"(\")"; break;
+      case '\\': out += R"(\\)"; break;
       case '\n': out += "\\n"; break;
       case '\r': out += "\\r"; break;
       case '\t': out += "\\t"; break;
@@ -85,7 +88,7 @@ namespace tts
       // file from line so consumers get a real integer instead of a string to parse themselves.
       char const* loc      = location.data();
       std::size_t len      = strlen(loc); // NOSONAR - loc always comes from a well-formed tts::text
-      text        stripped = text {"%.*s", static_cast<int>(len - 2), loc + 1};
+      auto        stripped = text {"%.*s", static_cast<int>(len - 2), loc + 1};
 
       char const* colon    = strrchr(stripped.data(), ':'); // NOSONAR - stripped always has one
       text        file =
@@ -94,8 +97,8 @@ namespace tts
       if(colon) sscanf(colon + 1, "%d", &line); // NOSONAR - colon+1 is always digits here
 
       if(!current_failures_.is_empty()) current_failures_ += ",";
-      current_failures_ += text {"{\"location\":{\"file\":\"%s\",\"line\":%d},\"message\":\"%s\","
-                                 "\"fatal\":%s}",
+      current_failures_ += text {R"({"location":{"file":"%s","line":%d},"message":"%s",)"
+                                 R"("fatal":%s})",
                                  _::json_escape(file).data(),
                                  line,
                                  _::json_escape(message).data(),
@@ -107,14 +110,22 @@ namespace tts
                        bool               invalid,
                        unsigned long long duration_ns) override
     {
-      char const* status = invalid ? "invalid" : passed ? "passed" : "failed";
-      if(invalid) ++invalid_count_;
-      else if(passed) ++passed_count_;
+      char const* status = "failed";
+      if(invalid)
+      {
+        status = "invalid";
+        ++invalid_count_;
+      }
+      else if(passed)
+      {
+        status = "passed";
+        ++passed_count_;
+      }
       else ++failed_count_;
       total_duration_ns_ += duration_ns;
 
       if(!body_.is_empty()) body_ += ",";
-      body_ += text {"{\"name\":\"%s\",\"status\":\"%s\",\"duration_ns\":%llu,\"failures\":[%s]}",
+      body_ += text {R"({"name":"%s","status":"%s","duration_ns":%llu,"failures":[%s]})",
                      _::json_escape(name).data(),
                      status,
                      duration_ns,
@@ -127,8 +138,8 @@ namespace tts
     text render() const
     {
       unsigned long long total = passed_count_ + failed_count_ + invalid_count_;
-      return text {"{\"tests\":[%s],\"summary\":{\"total\":%llu,\"passed\":%llu,\"failed\":%llu,"
-                   "\"invalid\":%llu,\"duration_ns\":%llu}}",
+      return text {R"({"tests":[%s],"summary":{"total":%llu,"passed":%llu,"failed":%llu,)"
+                   R"("invalid":%llu,"duration_ns":%llu}})",
                    body_.data(),
                    total,
                    passed_count_,
@@ -178,3 +189,5 @@ namespace tts
     unsigned long long total_duration_ns_ = 0;
   };
 }
+
+TTS_DISABLE_WARNING_POP

--- a/include/tts/sinks/sinks.hpp
+++ b/include/tts/sinks/sinks.hpp
@@ -10,6 +10,7 @@
 
 #include <tts/sinks/colorized.hpp>
 #include <tts/sinks/diagnostics.hpp>
+#include <tts/sinks/json.hpp>
 #include <tts/sinks/tap.hpp>
 
 //======================================================================================================================

--- a/include/tts/tools/source_location.hpp
+++ b/include/tts/tools/source_location.hpp
@@ -17,8 +17,13 @@ namespace tts::_
     [[nodiscard]] static auto current(char const* file = __builtin_FILE(),
                                       int         line = __builtin_LINE()) noexcept
     {
+      // __builtin_FILE() uses whatever separator the compiler was invoked with - '/' almost
+      // everywhere, but '\' on Windows - so both need checking to reliably keep just the
+      // basename; picking only '/' left the full absolute path in place on MSVC/clang-cl.
       int  offset = 0;
-      auto end    = strrchr(file, '/');
+      auto slash  = strrchr(file, '/');
+      auto bslash = strrchr(file, '\\');
+      auto end    = (bslash && (!slash || bslash > slash)) ? bslash : slash;
       if(end) offset = static_cast<int>(end - file + 1);
 
       source_location that {};

--- a/test/unit/tests/sinks.cpp
+++ b/test/unit/tests/sinks.cpp
@@ -106,10 +106,8 @@ int main(int argc, char const** argv)
     ok =
     ok && (strstr(content, "\"message\":\"Expression: 1 == 2 evaluates to false.\"") != // NOSONAR
            nullptr);
-    ok =
-    ok && (strstr(content,
-                  "\"summary\":{\"total\":2,\"passed\":1,\"failed\":1,\"invalid\":0,") != // NOSONAR
-           nullptr);
+    char const* summary = "\"total\":2,\"passed\":1,\"failed\":1,\"invalid\":0";
+    ok                  = ok && (strstr(content, summary) != nullptr); // NOSONAR
   }
 
   return ok ? 0 : 1;

--- a/test/unit/tests/sinks.cpp
+++ b/test/unit/tests/sinks.cpp
@@ -102,6 +102,8 @@ int main(int argc, char const** argv)
     ok = ok && (strstr(content, "\"name\":\"Failing case for sink tests\"") != nullptr); // NOSONAR
     ok = ok && (strstr(content, "\"status\":\"failed\"") != nullptr);                    // NOSONAR
     ok =
+    ok && (strstr(content, "\"location\":{\"file\":\"sinks.cpp\",\"line\":") != nullptr); // NOSONAR
+    ok =
     ok && (strstr(content, "\"message\":\"Expression: 1 == 2 evaluates to false.\"") != // NOSONAR
            nullptr);
     ok =

--- a/test/unit/tests/sinks.cpp
+++ b/test/unit/tests/sinks.cpp
@@ -83,5 +83,32 @@ int main(int argc, char const** argv)
          (strstr(content, ": error: Expression: 1 == 2 evaluates to false.") != nullptr); // NOSONAR
   }
 
+  // json_sink renders one "tests" entry per TTS_CASE plus a case-level "summary", built from the
+  // structured hooks - the counts must match what actually ran, not the suite's raw assertion
+  // totals.
+  {
+    tts::json_sink json;
+    {
+      tts::scoped_sink scope(json);
+      sinks_test_main(argc, argv);
+    }
+
+    tts::gathering_sink target;
+    json.dump(target);
+    char const* content = target.content().data();
+
+    ok = ok && (strstr(content, "\"name\":\"Passing case for sink tests\"") != nullptr); // NOSONAR
+    ok = ok && (strstr(content, "\"status\":\"passed\"") != nullptr);                    // NOSONAR
+    ok = ok && (strstr(content, "\"name\":\"Failing case for sink tests\"") != nullptr); // NOSONAR
+    ok = ok && (strstr(content, "\"status\":\"failed\"") != nullptr);                    // NOSONAR
+    ok =
+    ok && (strstr(content, "\"message\":\"Expression: 1 == 2 evaluates to false.\"") != // NOSONAR
+           nullptr);
+    ok =
+    ok && (strstr(content,
+                  "\"summary\":{\"total\":2,\"passed\":1,\"failed\":1,\"invalid\":0,") != // NOSONAR
+           nullptr);
+  }
+
   return ok ? 0 : 1;
 }

--- a/test/unit/tests/sinks.cpp
+++ b/test/unit/tests/sinks.cpp
@@ -106,7 +106,7 @@ int main(int argc, char const** argv)
     ok =
     ok && (strstr(content, "\"message\":\"Expression: 1 == 2 evaluates to false.\"") != // NOSONAR
            nullptr);
-    char const* summary = "\"total\":2,\"passed\":1,\"failed\":1,\"invalid\":0";
+    char const* summary = R"("total":2,"passed":1,"failed":1,"invalid":0)";
     ok                  = ok && (strstr(content, summary) != nullptr); // NOSONAR
   }
 


### PR DESCRIPTION
Structured JSON report built from the same output_sink hooks as tap_sink/diagnostics_sink, not from parsing the text stream - one entry per TTS_CASE (name, status, duration_ns, any failing/fatal assertions) plus a summary counted from test_finished() directly, so tests.length always matches summary.total. No JSON library involved: escaping is hand-rolled, matching the project's compile-time-budget stance.

Also restructured the Built-in Output Sinks doc page for consistency: every sink now has Effect/Manual Usage/CLI Flag/Example subsections running the same shared sample suite, with real captured output instead of hand-written examples.