### PR TITLE
Fix #164 (4/N) - Add tts::junit_sink, wire up --sink=junit

### DIFF
--- a/doc/cli.hpp
+++ b/doc/cli.hpp
@@ -65,7 +65,7 @@
   `--allow-empty`   | Do not fail when the test suite registered zero test. `./my_test --allow-empty`
   `--capture=path`  | Capture this run's output and write it to `path` instead of stdout. `./my_test --capture=report.txt`
   `--shard=i/n`     | Only run the tests in shard `i` of `n` (`0 <= i < n`). `./my_test --shard=1/3`
-  `--sink=name`     | Format output as `name` (`colored`, `tap`, `diagnostics`, or `json`) - see @ref output-sinks. `./my_test --sink=tap`
+  `--sink=name`     | Format output as `name` (`colored`, `tap`, `diagnostics`, `json`, or `junit`) - see @ref output-sinks. `./my_test --sink=tap`
 
   @note `--shard=i/n` partitions tests by registration index, round-robin (test at index `k`
   belongs to shard `k % n`), not by contiguous blocks - this keeps shards balanced even when

--- a/doc/sinks.hpp
+++ b/doc/sinks.hpp
@@ -14,7 +14,7 @@
   `include/tts/sinks/`, already available through `#include <tts/tts.hpp>` with no extra include
   needed.
 
-  All four draw from @ref tts::output_sink's structured hooks (`test_started()`,
+  All five draw from @ref tts::output_sink's structured hooks (`test_started()`,
   `assertion_failed()`, `test_finished()`, `suite_finished()`, `suite_metric()`,
   `suite_aborted()`) rather than by parsing the text `tts::stdout_sink` prints, so they stay
   correct regardless of `-v`/`-q`. None of them currently reflect @ref TTS_CASE_TPL's per-type
@@ -41,8 +41,8 @@
   @endcode
 
   @note On a plain @ref TTS_MAIN binary (no custom driver), the `--sink=name` CLI flag installs
-  any of the four below without writing any C++ at all - `--sink=colored`, `--sink=tap`,
-  `--sink=diagnostics`, or `--sink=json`. It composes with `--capture=path`:
+  any of the five below without writing any C++ at all - `--sink=colored`, `--sink=tap`,
+  `--sink=diagnostics`, `--sink=json`, or `--sink=junit`. It composes with `--capture=path`:
   `--sink=tap --capture=report.tap` writes TAP-formatted output to the file instead of stdout.
   Like `--shard`, it's a no-op for binaries using a @ref TTS_CUSTOM_DRIVER_FUNCTION, which
   already manages its own sink - see @ref cli for the full flag reference.
@@ -50,8 +50,8 @@
   # Simple Format Sinks
 
   Each of these produces plain, line-oriented text - as opposed to a structured-format sink like
-  @ref tts::json_sink below, which assembles a single well-formed document with its own schema
-  instead of just lines of text.
+  @ref tts::json_sink or @ref tts::junit_sink below, which each assemble a single well-formed
+  document with its own schema instead of just lines of text.
 
   ## %tts::colorized_sink
 
@@ -167,8 +167,8 @@
 
   # Structured Format Sinks
 
-  Unlike the simple sinks above, this one assembles its output into a single well-formed
-  document with its own schema instead of printing independent lines - so it only ever produces
+  Unlike the simple sinks above, each of these assembles its output into a single well-formed
+  document with its own schema instead of printing independent lines - so they only ever produce
   output once the whole run has finished, via `dump()` or `finish()`, never incrementally.
 
   ## %tts::json_sink
@@ -290,6 +290,90 @@
       "duration_ns": 12015
     }
   }
+  @endcode
+
+  ## %tts::junit_sink
+
+  ### Effect
+
+  Renders the run as JUnit XML, the de facto standard test-report format consumed by Jenkins,
+  GitLab CI, CircleCI, Azure DevOps, Bitbucket Pipelines and most CI dashboards - including
+  GitHub Actions itself via a separate report-parsing action (e.g. `dorny/test-reporter`,
+  `mikepenz/action-junit-report`), which is the standard way JUnit XML turns into inline PR
+  annotations. Every @ref TTS_CASE becomes one `<testcase>` inside a single `<testsuite>`,
+  counted from `test_finished()` directly rather than the suite's raw assertion totals, exactly
+  like @ref tts::json_sink.
+
+  ### Schema
+
+  `<testsuites>` wraps a single `<testsuite>`:
+
+  Attribute   | Description
+  ----------- | -------------------------------------------------------------------------------
+  `name`      | Fixed at `"TTS"` - TTS only ever reports one flat suite.
+  `tests`     | Total number of `<testcase>` entries (passed + failed + skipped).
+  `failures`  | Number of `<testcase>` entries with a `<failure>` child.
+  `errors`    | Always `0` - see the @ref TTS_FATAL note below.
+  `skipped`   | Number of `<testcase>` entries with a `<skipped/>` child (invalid cases).
+  `time`      | Sum of every case's elapsed time, in seconds.
+
+  Each `<testcase>`:
+
+  Attribute/child | Description
+  --------------- | ---------------------------------------------------------------------------
+  `name`          | The case's ID, exactly as given to @ref TTS_CASE.
+  `classname`     | Duplicates `name` - TTS has no class-like grouping to report instead.
+  `time`          | Elapsed time for this case, in seconds.
+  `<skipped/>`    | Present, empty, if the case registered no assertion at all.
+  `<failure>`     | Present if at least one assertion failed - `message` attribute is the first failure's message, text content is every failing assertion's `path:line: message`, one per line.
+
+  Neither `<skipped/>` nor `<failure>` is present for a passed case - just a self-closing
+  `<testcase .../>`.
+
+  @note Exactly like @ref tts::json_sink's `tests` array, a @ref TTS_FATAL assertion aborts the
+  whole suite before the case it happened in ever reaches `test_finished()`, so that case never
+  becomes a `<testcase>` at all - not even one with a `<failure>` or an `<error>` child. This is
+  also why `errors` is always `0`: TTS has no way to represent "aborted mid-case" as a
+  finished testcase, so there's nothing to ever count there.
+
+  ### Manual Usage
+
+  @code{cpp}
+  tts::junit_sink junit;
+  tts::output().sink(junit);
+
+  // ... run the test suite ...
+
+  junit.dump(); // stream the JUnit XML report to stdout
+  @endcode
+
+  ### CLI Flag
+
+  `./my_test --sink=junit`
+
+  ### Example
+
+  Running the sample suite above via `--sink=junit` produces (pretty-printed here for
+  readability):
+
+  @code{xml}
+  <?xml version="1.0" encoding="UTF-8"?>
+  <testsuites>
+    <testsuite name="TTS" tests="3" failures="1" errors="0" skipped="1" time="0.000012">
+      <testcase name="Check that expectation can be met"
+                classname="Check that expectation can be met" time="0.000001"/>
+      <testcase name="Check invalid detection" classname="Check invalid detection"
+                time="0.000000">
+        <skipped/>
+      </testcase>
+      <testcase name="Check that expectation fails" classname="Check that expectation fails"
+                time="0.000011">
+        <failure message="Expression: 1 == 2 evaluates to false.">
+          expect.cpp:15: Expression: 1 == 2 evaluates to false.
+        </failure>
+      </testcase>
+    </testsuite>
+  </testsuites>
   @endcode
 **/
 //==================================================================================================

--- a/include/tts/engine/main.hpp
+++ b/include/tts/engine/main.hpp
@@ -194,6 +194,7 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
   ::tts::tap_sink         tap_candidate {capture_target};
   ::tts::diagnostics_sink diagnostics_candidate {capture_target};
   ::tts::json_sink        json_candidate {capture_target};
+  ::tts::junit_sink       junit_candidate {capture_target};
 
   // Neither flag given: leave whatever sink the caller already installed alone, exactly as
   // before --sink existed - only touch output().sink() when there's an actual reason to.
@@ -202,6 +203,7 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
   else if(sink_name == "tap") ::tts::output().sink(tap_candidate);
   else if(sink_name == "diagnostics") ::tts::output().sink(diagnostics_candidate);
   else if(sink_name == "json") ::tts::output().sink(json_candidate);
+  else if(sink_name == "junit") ::tts::output().sink(junit_candidate);
 
   auto        nb_tests   = shard.count(::tts::_::suite().size());
   std::size_t done_tests = 0;

--- a/include/tts/engine/sink_selection.hpp
+++ b/include/tts/engine/sink_selection.hpp
@@ -15,7 +15,11 @@ namespace tts::_
 {
   // Every accepted --sink=name value - also drives the "expected one of: ..." error message
   // below, so adding a new sink here is the only place that needs updating.
-  inline constexpr std::array<char const*, 4> sink_names {"colored", "tap", "diagnostics", "json"};
+  inline constexpr std::array<char const*, 5> sink_names {"colored",
+                                                          "tap",
+                                                          "diagnostics",
+                                                          "json",
+                                                          "junit"};
 
   // Validates --sink=name (read from the current tts::arguments()). ok is set to false for an
   // unknown, non-empty name, in which case the returned text is ready to print as an error.

--- a/include/tts/sinks/junit.hpp
+++ b/include/tts/sinks/junit.hpp
@@ -1,0 +1,203 @@
+//======================================================================================================================
+//! @file
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//======================================================================================================================
+#pragma once
+
+#include <tts/tools/output.hpp>
+
+namespace tts::_
+{
+  // Escapes t for embedding in XML text/attribute content - test names and failure messages are
+  // arbitrary user text, so this is the only thing standing between them and invalid XML.
+  inline ::tts::text xml_escape(::tts::text const& t)
+  {
+    ::tts::text out;
+    for(char c: t)
+    {
+      switch(c)
+      {
+      case '&': out += "&amp;"; break;
+      case '<': out += "&lt;"; break;
+      case '>': out += "&gt;"; break;
+      case '"': out += "&quot;"; break;
+      case '\'': out += "&apos;"; break;
+      default:
+        // XML 1.0 forbids raw control characters outright (no valid escape for them) except
+        // tab/newline/CR - drop the rest instead of producing a document no parser can read.
+        if(static_cast<unsigned char>(c) >= 0x20 || c == '\t' || c == '\n' || c == '\r')
+          out += ::tts::text {"%c", c};
+        break;
+      }
+    }
+    return out;
+  }
+}
+
+namespace tts
+{
+  //====================================================================================================================
+  /**
+    @ingroup tools-sinks
+    @public
+    @brief output_sink rendering the run as JUnit XML, the de facto standard consumed by Jenkins,
+    GitLab CI, CircleCI, Azure DevOps, Bitbucket Pipelines and most CI dashboards.
+
+    Built from @ref output_sink's structured hooks rather than by parsing the human-readable text
+    @ref tts::stdout_sink prints, so it stays correct regardless of `-v`/`-q`. Every @ref TTS_CASE
+    becomes one `<testcase>` (name, classname, elapsed time in seconds) inside a single
+    `<testsuite>`, with a `<skipped/>` child for an invalid case or a `<failure>` child gathering
+    every failing assertion's message for a failed one. Rendered by `dump()`, or automatically via
+    `finish()`, to the target given at construction (`tts::output_handler::default_sink()` by
+    default). It does not (currently) reflect @ref TTS_CASE_TPL's per-type breakdown or
+    @ref TTS_WHEN / @ref TTS_AND_THEN sub-scenarios, since those don't have their own hook - only
+    the enclosing @ref TTS_CASE does.
+
+    @groupheader{Example}
+    @code
+    tts::junit_sink junit;
+    tts::output().sink(junit);
+
+    // ... run the test suite ...
+
+    junit.dump(); // stream the JUnit XML report to stdout
+    @endcode
+  **/
+  //====================================================================================================================
+  struct junit_sink : output_sink
+  {
+    explicit junit_sink(output_sink& target = output_handler::default_sink())
+        : target_(&target)
+    {
+    }
+
+    void write(text const&) override
+    {
+      // Intentionally empty: the JUnit report is built entirely from the structured hooks below.
+    }
+
+    void assertion_failed(text const&           location,
+                          text const&           message,
+                          [[maybe_unused]] bool fatal) override
+    {
+      // location is "[file:line]" (see tts::_::source_location) - strip the brackets to match
+      // tts::diagnostics_sink's own "file:line: message" convention.
+      char const* loc = location.data();
+      std::size_t len = strlen(loc); // NOSONAR - loc always comes from a well-formed tts::text
+
+      if(!current_failures_.is_empty()) current_failures_ += "&#10;"; // XML newline entity
+      current_failures_ +=
+      text {"%.*s: %s", static_cast<int>(len - 2), loc + 1, _::xml_escape(message).data()};
+
+      if(first_failure_.is_empty()) first_failure_ = _::xml_escape(message);
+    }
+
+    void test_finished(text const&        name,
+                       bool               passed,
+                       bool               invalid,
+                       unsigned long long duration_ns) override
+    {
+      if(invalid) ++invalid_count_;
+      else if(passed) ++passed_count_;
+      else ++failed_count_;
+      total_duration_ns_ += duration_ns;
+
+      text escaped_name   = _::xml_escape(name);
+      text seconds        = text {"%.6f", static_cast<double>(duration_ns) / 1'000'000'000.0};
+
+      if(invalid)
+      {
+        body_ += text {R"(    <testcase name="%s" classname="%s" time="%s"><skipped/></testcase>)"
+                       "\n",
+                       escaped_name.data(),
+                       escaped_name.data(),
+                       seconds.data()};
+      }
+      else if(!passed)
+      {
+        body_ += text {R"(    <testcase name="%s" classname="%s" time="%s"><failure )"
+                       R"(message="%s">%s</failure></testcase>)"
+                       "\n",
+                       escaped_name.data(),
+                       escaped_name.data(),
+                       seconds.data(),
+                       first_failure_.data(),
+                       current_failures_.data()};
+      }
+      else
+      {
+        body_ += text {R"(    <testcase name="%s" classname="%s" time="%s"/>)"
+                       "\n",
+                       escaped_name.data(),
+                       escaped_name.data(),
+                       seconds.data()};
+      }
+
+      current_failures_ = text {};
+      first_failure_    = text {};
+    }
+
+    /// Renders everything gathered so far as a single JUnit XML document.
+    text render() const
+    {
+      unsigned long long total   = passed_count_ + failed_count_ + invalid_count_;
+      double             seconds = static_cast<double>(total_duration_ns_) / 1'000'000'000.0;
+
+      return text {"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                   R"(<testsuites><testsuite name="TTS" tests="%llu" failures="%llu" errors="0")"
+                   R"( skipped="%llu" time="%.6f">)"
+                   "\n%s  </testsuite></testsuites>\n",
+                   total,
+                   failed_count_,
+                   invalid_count_,
+                   seconds,
+                   body_.data()};
+    }
+
+    /// Forwards the JUnit-rendered report to target, then clears the gathered results.
+    void dump(output_sink& target)
+    {
+      target.write(render());
+      clear();
+    }
+
+    /// Streams the JUnit-rendered report to `stdout`, then clears the gathered results.
+    void dump()
+    {
+      stdout_sink target;
+      dump(target);
+    }
+
+    /// Discards everything gathered so far.
+    void clear()
+    {
+      body_              = text {};
+      current_failures_  = text {};
+      first_failure_     = text {};
+      passed_count_      = 0;
+      failed_count_      = 0;
+      invalid_count_     = 0;
+      total_duration_ns_ = 0;
+    }
+
+    /// Dumps the JUnit-rendered report to the target given at construction.
+    void finish() override
+    {
+      dump(*target_);
+    }
+
+  private:
+    output_sink*       target_;
+    text               body_;
+    text               current_failures_;
+    text               first_failure_;
+    unsigned long long passed_count_      = 0;
+    unsigned long long failed_count_      = 0;
+    unsigned long long invalid_count_     = 0;
+    unsigned long long total_duration_ns_ = 0;
+  };
+}

--- a/include/tts/sinks/junit.hpp
+++ b/include/tts/sinks/junit.hpp
@@ -106,8 +106,8 @@ namespace tts
       else ++failed_count_;
       total_duration_ns_ += duration_ns;
 
-      text escaped_name   = _::xml_escape(name);
-      text seconds        = text {"%.6f", static_cast<double>(duration_ns) / 1'000'000'000.0};
+      auto escaped_name   = _::xml_escape(name);
+      auto seconds        = text {"%.6f", static_cast<double>(duration_ns) / 1'000'000'000.0};
 
       if(invalid)
       {

--- a/include/tts/sinks/sinks.hpp
+++ b/include/tts/sinks/sinks.hpp
@@ -11,6 +11,7 @@
 #include <tts/sinks/colorized.hpp>
 #include <tts/sinks/diagnostics.hpp>
 #include <tts/sinks/json.hpp>
+#include <tts/sinks/junit.hpp>
 #include <tts/sinks/tap.hpp>
 
 //======================================================================================================================

--- a/test/unit/tests/sinks.cpp
+++ b/test/unit/tests/sinks.cpp
@@ -19,14 +19,11 @@ TTS_CASE("Failing case for sink tests")
   TTS_EXPECT(1 == 2);
 };
 
-int main(int argc, char const** argv)
+namespace
 {
-  ::tts::initialize(argc, argv);
-
-  bool ok = true;
-
   // colorized_sink wraps a target sink and colors PASSED/FAILURE lines, including the
   // multi-fragment "Results: ..." summary, without breaking any content through.
+  bool check_colorized(int argc, char const** argv)
   {
     tts::gathering_sink target;
     tts::colorized_sink colorized {target};
@@ -37,6 +34,7 @@ int main(int argc, char const** argv)
     }
 
     char const* content = target.content().data();
+    bool        ok      = true;
     ok                  = ok && (strstr(content, "\033[32m") != nullptr);   // NOSONAR - green
     ok                  = ok && (strstr(content, "\033[31m") != nullptr);   // NOSONAR - red
     ok                  = ok && (strstr(content, "\033[0m") != nullptr);    // NOSONAR - reset
@@ -49,9 +47,11 @@ int main(int argc, char const** argv)
     ok = ok && (strstr(content, "\033[1mResults:") != nullptr); // NOSONAR
     ok = ok && (strstr(content, "\033[1;32m- 1/2") != nullptr); // NOSONAR - success
     ok = ok && (strstr(content, "\033[1;31m- 1/2") != nullptr); // NOSONAR - failure
+    return ok;
   }
 
   // tap_sink renders "1..N" / "ok" / "not ok" lines from the structured test_finished() events.
+  bool check_tap(int argc, char const** argv)
   {
     tts::tap_sink tap;
     {
@@ -63,12 +63,15 @@ int main(int argc, char const** argv)
     tap.dump(target);
     char const* content = target.content().data();
 
+    bool        ok      = true;
     ok                  = ok && (strstr(content, "1..2") != nullptr);                  // NOSONAR
     ok = ok && (strstr(content, "ok 1 - Passing case for sink tests") != nullptr);     // NOSONAR
     ok = ok && (strstr(content, "not ok 2 - Failing case for sink tests") != nullptr); // NOSONAR
+    return ok;
   }
 
   // diagnostics_sink adds a "file:line: error: message" line per failing/fatal assertion.
+  bool check_diagnostics(int argc, char const** argv)
   {
     tts::gathering_sink   target;
     tts::diagnostics_sink diagnostics {target};
@@ -78,14 +81,17 @@ int main(int argc, char const** argv)
     }
 
     char const* content = target.content().data();
+    bool        ok      = true;
     ok                  = ok && (strstr(content, "sinks.cpp:") != nullptr); // NOSONAR
     ok                  = ok &&
          (strstr(content, ": error: Expression: 1 == 2 evaluates to false.") != nullptr); // NOSONAR
+    return ok;
   }
 
   // json_sink renders one "tests" entry per TTS_CASE plus a case-level "summary", built from the
   // structured hooks - the counts must match what actually ran, not the suite's raw assertion
   // totals.
+  bool check_json(int argc, char const** argv)
   {
     tts::json_sink json;
     {
@@ -97,6 +103,7 @@ int main(int argc, char const** argv)
     json.dump(target);
     char const* content = target.content().data();
 
+    bool        ok      = true;
     ok = ok && (strstr(content, "\"name\":\"Passing case for sink tests\"") != nullptr); // NOSONAR
     ok = ok && (strstr(content, "\"status\":\"passed\"") != nullptr);                    // NOSONAR
     ok = ok && (strstr(content, "\"name\":\"Failing case for sink tests\"") != nullptr); // NOSONAR
@@ -108,10 +115,12 @@ int main(int argc, char const** argv)
            nullptr);
     char const* summary = R"("total":2,"passed":1,"failed":1,"invalid":0)";
     ok                  = ok && (strstr(content, summary) != nullptr); // NOSONAR
+    return ok;
   }
 
   // junit_sink renders one <testcase> per TTS_CASE inside a single <testsuite>, with a
   // <failure> child gathering every failing assertion for a failed case.
+  bool check_junit(int argc, char const** argv)
   {
     tts::junit_sink junit;
     {
@@ -125,15 +134,29 @@ int main(int argc, char const** argv)
 
     char const* suite_header = R"(<testsuite name="TTS" tests="2" failures="1" errors="0")"
                                R"( skipped="0")";
+    bool        ok           = true;
     ok                       = ok && (strstr(content, suite_header) != nullptr); // NOSONAR
     ok                       = ok &&
          (strstr(content, R"(<testcase name="Passing case for sink tests")") != nullptr); // NOSONAR
     ok = ok &&
          (strstr(content, R"(<testcase name="Failing case for sink tests")") != nullptr); // NOSONAR
-    ok = ok && (strstr(content,
-                       R"(<failure message="Expression: 1 == 2 evaluates to false.")" // NOSONAR
-                       R"(>sinks.cpp:)") != nullptr);
+    char const* failure_marker = R"(<failure message="Expression: 1 == 2 evaluates to false.")"
+                                 R"(>sinks.cpp:)";
+    ok                         = ok && (strstr(content, failure_marker) != nullptr); // NOSONAR
+    return ok;
   }
+}
+
+int main(int argc, char const** argv)
+{
+  ::tts::initialize(argc, argv);
+
+  bool ok = true;
+  ok      = ok && check_colorized(argc, argv);
+  ok      = ok && check_tap(argc, argv);
+  ok      = ok && check_diagnostics(argc, argv);
+  ok      = ok && check_json(argc, argv);
+  ok      = ok && check_junit(argc, argv);
 
   return ok ? 0 : 1;
 }

--- a/test/unit/tests/sinks.cpp
+++ b/test/unit/tests/sinks.cpp
@@ -110,5 +110,30 @@ int main(int argc, char const** argv)
     ok                  = ok && (strstr(content, summary) != nullptr); // NOSONAR
   }
 
+  // junit_sink renders one <testcase> per TTS_CASE inside a single <testsuite>, with a
+  // <failure> child gathering every failing assertion for a failed case.
+  {
+    tts::junit_sink junit;
+    {
+      tts::scoped_sink scope(junit);
+      sinks_test_main(argc, argv);
+    }
+
+    tts::gathering_sink target;
+    junit.dump(target);
+    char const* content      = target.content().data();
+
+    char const* suite_header = R"(<testsuite name="TTS" tests="2" failures="1" errors="0")"
+                               R"( skipped="0")";
+    ok                       = ok && (strstr(content, suite_header) != nullptr); // NOSONAR
+    ok                       = ok &&
+         (strstr(content, R"(<testcase name="Passing case for sink tests")") != nullptr); // NOSONAR
+    ok = ok &&
+         (strstr(content, R"(<testcase name="Failing case for sink tests")") != nullptr); // NOSONAR
+    ok = ok && (strstr(content,
+                       R"(<failure message="Expression: 1 == 2 evaluates to false.")" // NOSONAR
+                       R"(>sinks.cpp:)") != nullptr);
+  }
+
   return ok ? 0 : 1;
 }


### PR DESCRIPTION
JUnit XML, the format consumed by Jenkins, GitLab CI, CircleCI, Azure DevOps, Bitbucket Pipelines and most CI dashboards - including GitHub Actions itself via a separate report-parsing action. One <testcase> per TTS_CASE inside a single <testsuite>, counted from test_finished() like json_sink.

Verified against a real consumer (junitparser round-trips counts/names/messages/escaping correctly), not just well-formedness - a strict Ant-derived XSD rejects the output, but it also rejects pytest's own JUnit files, so that schema is stricter than real-world practice.