### PR TITLE
Tone down verbose implementation comments

### DIFF
--- a/doc/tutorial.hpp
+++ b/doc/tutorial.hpp
@@ -41,7 +41,7 @@
 
   Notice the `#define TTS_MAIN` line. This is used to notify **TTS** that the current translation unit will contain
   the **TTS** main entry point. You can use **TTS** in multiple translation units, but only one of them must have the
-  @ref TTS_MAIN macro enabled.
+  @ref TTS_MAIN macro enabled.
 
   The unit test reports the total number of tests performed, the number of passing tests, the number of failing tests
   and the number of invalid tests. In this case, unsurprisingly, our empty test is reported as invalid, as we consider

--- a/include/tts/engine/environment.hpp
+++ b/include/tts/engine/environment.hpp
@@ -55,10 +55,7 @@ namespace tts::_
 
       auto& out      = ::tts::output();
 
-      // Fires before separator() too, not just before "Results:" - colorized_sink keeps a color
-      // active across several consecutive lines until the next hook, so this also (deliberately)
-      // colors the separator, and overwrites any color a sink left dangling from the last test if
-      // that test's own closing line was suppressed by -q.
+      // Also cleans up a color colorized_sink left dangling by -q, not just "Results:".
       out.suite_finished(failure_count, invalid_count);
 
       ::tts::_::separator();
@@ -99,15 +96,11 @@ namespace tts::_
                   ::tts::_::format_duration(static_cast<double>(total_duration_ns)).data(),
                   ::tts::_::format_duration(avg_duration_ns).data());
 
-      // A shard landing on zero tests is an expected partition outcome, not a build/
-      // registration bug, so --shard implicitly behaves like --allow-empty here.
+      // A shard landing on zero tests is expected, not a bug - behaves like --allow-empty here.
       if(test_count == 0 && !::tts::arguments()("--allow-empty") && !::tts::arguments()("--shard"))
         return 1;
 
-      // No explicit fails/invalids given: fall back to per-case expected-outcome tracking
-      // (TTS_XFAIL/TTS_MAYFAIL/TTS_XINVALID) instead of the raw success count - for a plain,
-      // untagged suite this is equivalent, since only a case that didn't pass raises
-      // unexpected_count.
+      // No explicit fails/invalids: unexpected_count alone decides pass/fail.
       if(!fails && !invalids) return unexpected_count == 0 ? 0 : 1;
       else return (failure_count == fails && invalid_count == invalids) ? 0 : 1;
     }

--- a/include/tts/engine/main.hpp
+++ b/include/tts/engine/main.hpp
@@ -80,8 +80,7 @@ namespace tts::_
 //======================================================================================================================
 namespace tts::_
 {
-  // Shared by report_fail/report_fatal: outside of verbose mode, the failing type isn't shown
-  // anywhere else, so it gets reported here instead.
+  // Shared by report_fail/report_fatal - the only place the failing type shows up outside verbose.
   void report_type_hint(::tts::text const& type)
   {
     if(!::tts::is_verbose() && !type.is_empty())
@@ -133,10 +132,7 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
     return 1;
   }
 
-  // --shard only makes sense for the default "everything that ran must pass" driver: a custom
-  // driver's caller typically expects a fixed, whole-suite fail/invalid count from
-  // tts::report(fails, invalids), which round-robin partitioning has no way to redistribute
-  // correctly, so --shard is a no-op there instead of risking a spurious pass or failure.
+  // No-op for a custom driver: tts::report(fails, invalids) expects the whole suite's count.
   if constexpr(!::tts::_::use_main) shard.active = false;
 
   if(::tts::arguments()("--dry"))
@@ -168,17 +164,12 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
     }
   }
 
-  // Format (--sink) and destination (--capture) are orthogonal: every candidate sink below
-  // targets capture_target, so --sink=X --capture=path writes X-formatted output to the file
-  // exactly like --sink=X alone writes it to stdout.
+  // --sink and --capture are orthogonal - every candidate sink below targets capture_target.
   ::tts::gathering_sink capture_sink;
   ::tts::output_sink& capture_target = capture_file ? static_cast<::tts::output_sink&>(capture_sink)
                                                     : ::tts::output_handler::default_sink();
 
-  // Like --shard, --sink only makes sense for the default TTS_MAIN driver: a custom driver
-  // already manages its own sink lifecycle (installing it, dumping accumulate-style ones, ...),
-  // so letting --sink install a different one out from under it, or finish() below fire on
-  // whatever it installed, would fight that instead of helping.
+  // Like --shard, no-op for a custom driver: it already manages its own sink lifecycle.
   ::tts::text sink_name = ::tts::arguments().value<::tts::text>("--sink");
   if constexpr(!::tts::_::use_main) sink_name = ::tts::text {};
 
@@ -196,8 +187,7 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
   ::tts::json_sink        json_candidate {capture_target};
   ::tts::junit_sink       junit_candidate {capture_target};
 
-  // Neither flag given: leave whatever sink the caller already installed alone, exactly as
-  // before --sink existed - only touch output().sink() when there's an actual reason to.
+  // Neither flag given: leave whatever sink is already installed alone.
   if(sink_name.is_empty() && capture_file) ::tts::output().sink(capture_sink);
   else if(sink_name == "colored") ::tts::output().sink(colorized_candidate);
   else if(sink_name == "tap") ::tts::output().sink(tap_candidate);
@@ -234,8 +224,7 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
       if(!::tts::is_quiet()) ::tts::output().writeln("TEST: '%s'", t.name);
       ::tts::output().flush();
 
-      // Always measured, regardless of --verbose: sinks (and the aggregate Total Time: line)
-      // need it even when the per-test text display below doesn't show it.
+      // Always measured regardless of --verbose - sinks and the Total Time: line need it either way.
       auto start_ns = ::tts::_::now_ns();
       t();
       auto duration_ns = ::tts::_::now_ns() - start_ns;
@@ -246,8 +235,7 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
       bool invalid                             = (test_count == ::tts::global_runtime.test_count);
       bool passed = !invalid && (failure_count == ::tts::global_runtime.failure_count);
 
-      // What actually happened (invalid/passed above) never changes based on the case's tag -
-      // only whether that actual result is what the case itself declared to expect does.
+      // invalid/passed reflect what happened, not the tag - only the comparison below does.
       bool matches_expectation = false;
       using enum ::tts::expected_outcome;
       switch(t.tag)
@@ -306,10 +294,7 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
   }
   catch(::tts::_::fatal_signal&)
   {
-    // The aborted case's own tag was never compared against its (nonexistent) actual outcome -
-    // t() never returned, so the driver loop's per-case bookkeeping above never ran for it. A
-    // fatal abort is always unexpected for the suite regardless of that case's tag, so count it
-    // here instead - otherwise a suite that aborts via TTS_FATAL could still report success.
+    // t() never returned, so per-case bookkeeping above never ran - count the abort here instead.
     ::tts::global_runtime.unexpected();
 
     ::tts::output().suite_aborted();
@@ -319,8 +304,7 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
                               static_cast<int>(nb_tests - done_tests - 1));
   }
 
-  // finish() is part of the same TTS_MAIN-only convenience as --sink above: a custom driver's own
-  // code decides when (or whether) to dump an accumulate-style sink it installed itself.
+  // finish() is TTS_MAIN-only, like --sink - a custom driver decides for itself when to dump its own sink.
   int exit_code = 0;
   if constexpr(::tts::_::use_main)
   {

--- a/include/tts/engine/test.hpp
+++ b/include/tts/engine/test.hpp
@@ -34,9 +34,7 @@ namespace tts::_
 {
   inline char const* current_test = "";
 
-  // Produced by TTS_XFAIL/TTS_MAYFAIL/TTS_XINVALID, consumed by capture/captures/test_generators's
-  // tagged constructor overload - carries the outcome tag through to test registration without
-  // changing what a case's ID argument itself looks like for the common, untagged case.
+  // Carries a TTS_XFAIL/TTS_MAYFAIL/TTS_XINVALID tag without changing TTS_CASE(ID)'s call shape.
   struct tagged_id
   {
     char const*             name;

--- a/include/tts/sinks/colorized.hpp
+++ b/include/tts/sinks/colorized.hpp
@@ -40,10 +40,8 @@ namespace tts
     {
       char const* s = t.data();
 
-      // A logical line (e.g. the final "Results: ..." summary) can span several write() calls -
-      // "\n" only closes the CURRENT line's coloring (color_applied_), not active_color_ itself,
-      // so a single hook can color several consecutive lines (e.g. the separator right before
-      // Results:) the same way, until the next hook decides otherwise.
+      // "\n" ends the current line's color only, not active_color_, so a hook's color can span
+      // several write() calls until the next hook changes it.
       if(strcmp(s, "\n") == 0) // NOSONAR - avoids std::string
       {
         if(color_applied_) target_->write(text {"\033[0m"}); // NOSONAR - \o{} is C++23-only
@@ -60,9 +58,7 @@ namespace tts
 
       target_->write(t);
 
-      // suite_metric() colors only its own segment (one write() call), not everything after it
-      // like the other hooks - once that segment is written, fall back to whatever color (if
-      // any) was active before it, e.g. bold-neutral for the Results: line it's part of.
+      // suite_metric() colors only its own segment - fall back once it's written.
       if(revert_to_)
       {
         active_color_  = revert_to_;
@@ -71,9 +67,7 @@ namespace tts
       }
     }
 
-    // Each hook below decisively sets or clears active_color_, rather than only setting it - a
-    // hook whose corresponding text is suppressed by -q must not leave a stale color for some
-    // later, unrelated write() to inherit.
+    // Each hook below sets or clears active_color_ decisively, even under -q.
 
     void test_started([[maybe_unused]] text const& name) override
     {

--- a/include/tts/sinks/json.hpp
+++ b/include/tts/sinks/json.hpp
@@ -15,8 +15,7 @@ TTS_DISABLE_WARNING_CRT_SECURE
 
 namespace tts::_
 {
-  // Escapes t for embedding in a JSON string literal - test names and failure messages are
-  // arbitrary user text, so this is the only thing standing between them and invalid JSON.
+  // Test names and failure messages are arbitrary user text - this is what keeps them valid JSON.
   inline ::tts::text json_escape(::tts::text const& t)
   {
     ::tts::text out;
@@ -84,8 +83,7 @@ namespace tts
 
     void assertion_failed(text const& location, text const& message, bool fatal) override
     {
-      // location is "[file:line]" (see tts::_::source_location) - strip the brackets, then split
-      // file from line so consumers get a real integer instead of a string to parse themselves.
+      // location is "[file:line]" - strip the brackets, split so line is a real integer.
       char const* loc      = location.data();
       std::size_t len      = strlen(loc); // NOSONAR - loc always comes from a well-formed tts::text
       auto        stripped = text {"%.*s", static_cast<int>(len - 2), loc + 1};

--- a/include/tts/sinks/junit.hpp
+++ b/include/tts/sinks/junit.hpp
@@ -12,8 +12,7 @@
 
 namespace tts::_
 {
-  // Escapes t for embedding in XML text/attribute content - test names and failure messages are
-  // arbitrary user text, so this is the only thing standing between them and invalid XML.
+  // Test names and failure messages are arbitrary user text - this is what keeps them valid XML.
   inline ::tts::text xml_escape(::tts::text const& t)
   {
     ::tts::text out;
@@ -27,8 +26,7 @@ namespace tts::_
       case '"': out += "&quot;"; break;
       case '\'': out += "&apos;"; break;
       default:
-        // XML 1.0 forbids raw control characters outright (no valid escape for them) except
-        // tab/newline/CR - drop the rest instead of producing a document no parser can read.
+        // XML 1.0 has no valid escape for raw control chars except tab/newline/CR - drop the rest.
         if(static_cast<unsigned char>(c) >= 0x20 || c == '\t' || c == '\n' || c == '\r')
           out += ::tts::text {"%c", c};
         break;
@@ -84,8 +82,7 @@ namespace tts
                           text const&           message,
                           [[maybe_unused]] bool fatal) override
     {
-      // location is "[file:line]" (see tts::_::source_location) - strip the brackets to match
-      // tts::diagnostics_sink's own "file:line: message" convention.
+      // Strip the brackets to match tts::diagnostics_sink's "file:line: message" convention.
       char const* loc = location.data();
       std::size_t len = strlen(loc); // NOSONAR - loc always comes from a well-formed tts::text
 

--- a/include/tts/tools/clock.hpp
+++ b/include/tts/tools/clock.hpp
@@ -21,11 +21,7 @@
 
 namespace tts::_
 {
-  // Monotonic timestamp in nanoseconds, for measuring elapsed durations between two calls - never
-  // a meaningful absolute point in time on its own. Not std::chrono: measured empirically at
-  // ~0.55-0.6s (5-6x) of extra compile time per translation unit, unacceptable in a header
-  // included by every user's test binary. windows.h with WIN32_LEAN_AND_MEAN/NOMINMAX measured
-  // as free (no significant cost vs. an empty translation unit) with cl.exe.
+  // Monotonic elapsed-time only, not std::chrono - see doc/compile_time.hpp.
   inline unsigned long long now_ns()
   {
 #if defined(_WIN32)
@@ -43,10 +39,7 @@ namespace tts::_
 #endif
   }
 
-  // Picks whichever of ns/us/ms/s keeps the displayed value in a readable range, instead of a
-  // fixed unit that reads as "0.000ms" for a trivial test or "15455566.123ms" for a slow suite.
-  // Thresholds sit half a displayed-digit below each power of 1000, so a value that would round
-  // up to e.g. "1000.000 ms" bumps to the next unit ("1.000 s") instead of showing four digits.
+  // Thresholds sit just below each power of 1000 so rounding can't show e.g. "1000.000 ms".
   inline ::tts::text format_duration(double duration_ns)
   {
     if(duration_ns < 999.5) return ::tts::text {"%.0f ns", duration_ns};

--- a/include/tts/tools/file.hpp
+++ b/include/tts/tools/file.hpp
@@ -13,10 +13,7 @@
 
 namespace tts::_
 {
-  // Move-only RAII wrapper around FILE*, closing it on destruction - so a caller's file stays
-  // closed on every return path, present or future, without having to remember to do it by hand
-  // at each one. Not std::unique_ptr: this project avoids <memory> for compile-time budget
-  // reasons (see doc/rationale.hpp).
+  // Not std::unique_ptr: avoids <memory> - see doc/compile_time.hpp.
   TTS_DISABLE_WARNING_PUSH
   TTS_DISABLE_WARNING_CRT_SECURE
   class file_guard

--- a/include/tts/tools/source_location.hpp
+++ b/include/tts/tools/source_location.hpp
@@ -17,9 +17,7 @@ namespace tts::_
     [[nodiscard]] static auto current(char const* file = __builtin_FILE(),
                                       int         line = __builtin_LINE()) noexcept
     {
-      // __builtin_FILE() uses whatever separator the compiler was invoked with - '/' almost
-      // everywhere, but '\' on Windows - so both need checking to reliably keep just the
-      // basename; picking only '/' left the full absolute path in place on MSVC/clang-cl.
+      // __builtin_FILE() uses '\' on Windows, '/' elsewhere - must check both.
       int  offset = 0;
       auto slash  = strrchr(file, '/');
       auto bslash = strrchr(file, '\\');

--- a/test/unit/tests/sinks.cpp
+++ b/test/unit/tests/sinks.cpp
@@ -21,8 +21,7 @@ TTS_CASE("Failing case for sink tests")
 
 namespace
 {
-  // colorized_sink wraps a target sink and colors PASSED/FAILURE lines, including the
-  // multi-fragment "Results: ..." summary, without breaking any content through.
+  // colorized_sink colors pass/fail lines and the "Results: ..." summary, unchanged otherwise.
   bool check_colorized(int argc, char const** argv)
   {
     tts::gathering_sink target;
@@ -88,9 +87,7 @@ namespace
     return ok;
   }
 
-  // json_sink renders one "tests" entry per TTS_CASE plus a case-level "summary", built from the
-  // structured hooks - the counts must match what actually ran, not the suite's raw assertion
-  // totals.
+  // json_sink counts must match what ran, not the suite's raw assertion totals.
   bool check_json(int argc, char const** argv)
   {
     tts::json_sink json;
@@ -118,8 +115,7 @@ namespace
     return ok;
   }
 
-  // junit_sink renders one <testcase> per TTS_CASE inside a single <testsuite>, with a
-  // <failure> child gathering every failing assertion for a failed case.
+  // junit_sink groups every failing assertion of a failed case into one <failure> child.
   bool check_junit(int argc, char const** argv)
   {
     tts::junit_sink junit;

--- a/test/unit/tests/suite_aborted.cpp
+++ b/test/unit/tests/suite_aborted.cpp
@@ -44,9 +44,7 @@ int main(int argc, char const** argv)
 
   bool ok = sink.aborted;
 
-  // A TTS_FATAL abort must make the implicit tts::report(0, 0) path (what TTS_MAIN calls
-  // automatically) reflect the failure - the aborted case's own bookkeeping never gets to run,
-  // so the driver's fatal_signal handler needs its own explicit accounting for this.
+  // A TTS_FATAL abort must still make tts::report(0, 0) reflect the failure.
   ok = ok && (::tts::report(0, 0) == 1);
 
   return ok ? 0 : 1;


### PR DESCRIPTION
Trims scattered inline // comments across the sinks/engine/tools code down to single lines, per the project's comment-brevity convention. Doc comments (///, /** */) are untouched. Also fixes a stray non-breaking space in doc/tutorial.hpp that left a line under-indented relative to its siblings.