### PR TITLE
Add code coverage reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,13 @@ jobs:
     uses: ./.github/workflows/sanitizers.yml
 
   ##################################################################################################
+  ## Coverage report - informational, runs alongside the gate without blocking the matrix
+  ##################################################################################################
+  coverage-report:
+    name: Coverage
+    uses: ./.github/workflows/coverage.yml
+
+  ##################################################################################################
   ## Unit Tests - the full compiler matrix, gated behind the fast checks above all passing
   ##################################################################################################
   linux-tests:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,12 +18,6 @@ jobs:
       - name: Fetch current branch
         uses: actions/checkout@v6
 
-      - name: Install gcovr
-        shell: bash
-        run: |
-          python3 -m pip install --quiet --break-system-packages gcovr \
-            || python3 -m pip install --quiet gcovr
-
       - name: Configure CMake and Build
         uses: ./.github/actions/config
         with:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,78 @@
+##======================================================================================================================
+##  TTS - Tiny Test System
+##  Copyright : TTS Contributors & Maintainers
+##  SPDX-License-Identifier: BSL-1.0
+##======================================================================================================================
+name: TTS Coverage
+on:
+  workflow_call:
+
+jobs:
+  coverage:
+    name: Coverage
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/jfalcou/compilers:v10
+
+    steps:
+      - name: Fetch current branch
+        uses: actions/checkout@v6
+
+      - name: Install gcovr
+        shell: bash
+        run: |
+          python3 -m pip install --quiet --break-system-packages gcovr \
+            || python3 -m pip install --quiet gcovr
+
+      - name: Configure CMake and Build
+        uses: ./.github/actions/config
+        with:
+          config: Debug
+          preset: gcc-coverage
+
+      - name: Run Unit Tests and Collect Coverage
+        shell: bash
+        run: cmake --build build/gcc-coverage --config Debug --target tts-coverage-report
+
+      - name: Report Coverage
+        shell: bash
+        run: |
+          python3 - "build/gcc-coverage/coverage/summary.json" >> "$GITHUB_STEP_SUMMARY" <<'EOF'
+          import json, sys
+
+          report = json.load(open(sys.argv[1]))
+
+          # gcovr reports no rate at all for a metric a header has no instance of - a branchless
+          # header is not 0% covered, it simply has nothing to say on that metric.
+          def rate(percent):
+            return "n/a" if percent is None else f"{percent:.1f}%"
+
+          def bar(percent):
+            filled = 0 if percent is None else round(percent / 5)
+            return "#" * filled + "." * (20 - filled)
+
+          print("## Coverage of `include/tts`\n")
+          print("| Metric | Covered | Total | Rate | |")
+          print("|---|---:|---:|---:|---|")
+          for name, key in [("Lines", "line"), ("Functions", "function"), ("Branches", "branch")]:
+            percent = report[f"{key}_percent"]
+            print(f"| {name} | {report[f'{key}_covered']} | {report[f'{key}_total']} "
+                  f"| {rate(percent)} | `{bar(percent)}` |")
+
+          print("\n<details><summary>Per-header breakdown</summary>\n")
+          print("| Header | Lines | Functions | Branches |")
+          print("|---|---:|---:|---:|")
+
+          # Worst first: the headers needing attention are the point of the table.
+          for entry in sorted(report["files"], key=lambda f: (f["line_percent"] is None, f["line_percent"])):
+            print(f"| `{entry['filename']}` | {rate(entry['line_percent'])} "
+                  f"| {rate(entry['function_percent'])} | {rate(entry['branch_percent'])} |")
+
+          print("\n</details>")
+          EOF
+
+      - name: Upload HTML Report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: build/gcc-coverage/coverage/

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -66,7 +66,7 @@ jobs:
           EOF
 
       - name: Upload HTML Report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: build/gcc-coverage/coverage/

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -29,8 +29,44 @@ jobs:
           cd build
           ninja tts-doxygen
 
+      ##################################################################################################
+      ## Coverage rides along with the documentation so both reach gh-pages in a single deployment,
+      ## which is what keeps one from wiping the other out.
+      ##################################################################################################
+      - name: Generate Coverage Report
+        run: |
+          cmake --preset gcc-coverage
+          cmake --build build/gcc-coverage --config Debug --target tts-coverage-report
+
+      - name: Assemble Coverage into the Site
+        run: |
+          cp -r build/gcc-coverage/coverage build/doc/coverage
+
+          python3 - build/gcc-coverage/coverage/summary.json build/doc/coverage/badge.json <<'EOF'
+          import json, sys
+
+          percent = json.load(open(sys.argv[1]))["line_percent"]
+
+          # Shields paints whatever colour it is handed, so the thresholds belong here.
+          for floor, colour in [(90, "brightgreen"), (75, "green"), (60, "yellow"), (40, "orange")]:
+            if percent >= floor:
+              break
+          else:
+            colour = "red"
+
+          json.dump( { "schemaVersion": 1
+                     , "label": "coverage"
+                     , "message": f"{percent:.1f}%"
+                     , "color": colour
+                     }
+                   , open(sys.argv[2], "w")
+                   )
+          EOF
+
+          cat build/doc/coverage/badge.json
+
       - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build/doc

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -66,7 +66,7 @@ jobs:
           cat build/doc/coverage/badge.json
 
       - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453 # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build/doc

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -40,13 +40,7 @@ jobs:
           wrapper: ${{ matrix.compiler.wrapper }}
           setup-script: ${{ matrix.compiler.setup }}
 
-      - name: Run Unit Tests
-        uses: ./.github/actions/test
-        with:
-          config: ${{ matrix.options }}
-          preset: ${{ matrix.compiler.preset }}
-
-      - name: Run MemCheck
+      - name: Run Unit Tests and MemCheck
         uses: ./.github/actions/test
         with:
           config: ${{ matrix.options }}

--- a/.github/workflows/package-standalone.yml
+++ b/.github/workflows/package-standalone.yml
@@ -43,7 +43,7 @@ jobs:
           git commit --allow-empty -m "Latest TTS standalone"
 
       - name: Push changes
-        uses: ad-m/github-push-action@master
+        uses: ad-m/github-push-action@881a6320fdb16eb5318c5054f31c218aec2b324c # v1.3.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branch: "standalone"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,11 +12,13 @@ endif()
 
 include(${PROJECT_SOURCE_DIR}/cmake/dependencies.cmake)
 include(${PROJECT_SOURCE_DIR}/cmake/compiler.cmake)
+include(${PROJECT_SOURCE_DIR}/cmake/coverage.cmake)
 
 ##======================================================================================================================
 option( TTS_BUILD_TEST          "Build tests for TTS"                                          ON  )
 option( TTS_BUILD_DOCUMENTATION "Build Doxygen for TTS"                                        OFF )
 option( TTS_ENABLE_SANITIZERS   "Build tests with AddressSanitizer + UndefinedBehaviorSanitizer" OFF )
+option( TTS_ENABLE_COVERAGE     "Build tests with code coverage instrumentation"               OFF )
 
 ##======================================================================================================================
 ## Project setup via copacabana
@@ -35,6 +37,7 @@ if(NOT TTS_QUIET)
   message(STATUS "[${PROJECT_NAME}] - Unit tests : ${TTS_BUILD_TEST} (via TTS_BUILD_TEST)")
   message(STATUS "[${PROJECT_NAME}] - Doxygen    : ${TTS_BUILD_DOCUMENTATION} (via TTS_BUILD_DOCUMENTATION)")
   message(STATUS "[${PROJECT_NAME}] - Sanitizers : ${TTS_ENABLE_SANITIZERS} (via TTS_ENABLE_SANITIZERS)")
+  message(STATUS "[${PROJECT_NAME}] - Coverage   : ${TTS_ENABLE_COVERAGE} (via TTS_ENABLE_COVERAGE)")
   set(QUIET_OPTION "")
 else()
   set(QUIET_OPTION "QUIET")
@@ -81,4 +84,9 @@ if(TTS_BUILD_TEST)
   enable_testing()
   add_custom_target(tts-unit)
   add_subdirectory(test)
+
+  # After the test targets exist, so the coverage targets can depend on them
+  if(TTS_ENABLE_COVERAGE)
+    tts_setup_coverage(tts_test)
+  endif()
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -81,8 +81,24 @@
       }
     },
     {
+      "name": "coverage",
+      "hidden": true,
+      "cacheVariables": {
+        "TTS_ENABLE_COVERAGE": "ON",
+        "CMAKE_DEFAULT_BUILD_TYPE": "Debug"
+      }
+    },
+    {
       "name": "gcc-sanitize",
       "inherits": ["gcc", "sanitize"]
+    },
+    {
+      "name": "gcc-coverage",
+      "inherits": ["gcc", "coverage"]
+    },
+    {
+      "name": "clang-coverage",
+      "inherits": ["clang", "coverage"]
     },
     {
       "name": "clang-sanitize",
@@ -155,6 +171,8 @@
     { "name": "clang"           , "inherits": "base-build", "configurePreset": "clang"          },
     { "name": "clang-libc++"    , "inherits": "base-build", "configurePreset": "clang-libc++"   },
     { "name": "gcc-sanitize"    , "inherits": "base-build", "configurePreset": "gcc-sanitize"   },
+    { "name": "gcc-coverage"    , "inherits": "base-build", "configurePreset": "gcc-coverage"   },
+    { "name": "clang-coverage"  , "inherits": "base-build", "configurePreset": "clang-coverage" },
     { "name": "clang-sanitize"  , "inherits": "base-build", "configurePreset": "clang-sanitize" },
     { "name": "icpx"            , "inherits": "base-build", "configurePreset": "icpx"           },
     { "name": "wasm"            , "inherits": "base-build", "configurePreset": "wasm"           },
@@ -173,6 +191,8 @@
     { "name": "clang"           , "inherits": "base-test", "configurePreset": "clang"           },
     { "name": "clang-libc++"    , "inherits": "base-test", "configurePreset": "clang-libc++"    },
     { "name": "gcc-sanitize"    , "inherits": "base-test", "configurePreset": "gcc-sanitize"    },
+    { "name": "gcc-coverage"    , "inherits": "base-test", "configurePreset": "gcc-coverage"    },
+    { "name": "clang-coverage"  , "inherits": "base-test", "configurePreset": "clang-coverage"  },
     { "name": "clang-sanitize"  , "inherits": "base-test", "configurePreset": "clang-sanitize"  },
     { "name": "icpx"            , "inherits": "base-test", "configurePreset": "icpx"            },
     { "name": "wasm"            , "inherits": "base-test", "configurePreset": "wasm"            },

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![License](https://img.shields.io/badge/license-BSL-green?style=plastic)](./LICENSE.md)
 [![Discord](https://img.shields.io/discord/692734675726237696?style=plastic)](https://discord.com/channels/692734675726237696/692735300522344468)
 [![CI Status](https://github.com/jfalcou/tts/actions/workflows/integration.yml/badge.svg)](https://github.com/jfalcou/tts/actions/workflows/integration.yml)
+[![Coverage](https://img.shields.io/endpoint?url=https://jfalcou.github.io/tts/coverage/badge.json&style=plastic)](https://jfalcou.github.io/tts/coverage/)
 
 **Tiny Test System** is a C++20 open-source Unit Test library designed following the ideas of
 libraries like CATCH or LEST.

--- a/cmake/coverage.cmake
+++ b/cmake/coverage.cmake
@@ -28,6 +28,19 @@ function(TTS_SETUP_COVERAGE target)
     message(FATAL_ERROR "[${PROJECT_NAME}] - Coverage requires gcovr, install it with 'pip install gcovr'")
   endif()
 
+  # gcovr 8 sums a header's lines once per translation unit including it instead of taking their
+  # union, which on a header-only template library reports totals larger than the files themselves.
+  execute_process( COMMAND ${GCOVR_EXECUTABLE} --version
+                   OUTPUT_VARIABLE GCOVR_VERSION_OUTPUT
+                   OUTPUT_STRIP_TRAILING_WHITESPACE
+                 )
+
+  if(GCOVR_VERSION_OUTPUT MATCHES "gcovr ([0-9]+)" AND CMAKE_MATCH_1 GREATER_EQUAL 8)
+    message(WARNING
+            "[${PROJECT_NAME}] - gcovr ${CMAKE_MATCH_1}.x inflates per-file totals on templates, "
+            "its numbers will not match the CI's gcovr 7.x")
+  endif()
+
   # Clang writes notes GCC's gcov cannot read, llvm-cov's gcov mode is what reads them back - and
   # only the one matching the compiler, hence looking for the versioned name first as distributions
   # usually ship no unsuffixed llvm-cov at all.

--- a/cmake/coverage.cmake
+++ b/cmake/coverage.cmake
@@ -1,0 +1,87 @@
+##======================================================================================================================
+##  TTS - Tiny Test System
+##  Copyright : TTS Contributors & Maintainers
+##  SPDX-License-Identifier: BSL-1.0
+##======================================================================================================================
+
+##======================================================================================================================
+## Instrument a target for coverage collection and setup the report generation targets
+##======================================================================================================================
+function(TTS_SETUP_COVERAGE target)
+  if(NOT (CMAKE_CXX_COMPILER_ID MATCHES "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "Clang"))
+    message(FATAL_ERROR "[${PROJECT_NAME}] - Coverage requires GCC or Clang, got ${CMAKE_CXX_COMPILER_ID}")
+  endif()
+
+  set(COVERAGE_FLAGS --coverage)
+
+  # Without this, GCC stores the notes' paths relative to the object file and gcov resolves none
+  # of the include/tts headers - which, for a header-only library, is the entirety of the report.
+  if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    list(APPEND COVERAGE_FLAGS -fprofile-abs-path)
+  endif()
+
+  target_compile_options(${target} INTERFACE $<$<COMPILE_LANGUAGE:CXX>:${COVERAGE_FLAGS}>)
+  target_link_options(${target} INTERFACE --coverage)
+
+  find_program(GCOVR_EXECUTABLE gcovr)
+  if(NOT GCOVR_EXECUTABLE)
+    message(FATAL_ERROR "[${PROJECT_NAME}] - Coverage requires gcovr, install it with 'pip install gcovr'")
+  endif()
+
+  # Clang writes notes GCC's gcov cannot read, llvm-cov's gcov mode is what reads them back - and
+  # only the one matching the compiler, hence looking for the versioned name first as distributions
+  # usually ship no unsuffixed llvm-cov at all.
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    string(REGEX MATCH "^[0-9]+" CLANG_VERSION "${CMAKE_CXX_COMPILER_VERSION}")
+    find_program(LLVM_COV_EXECUTABLE NAMES "llvm-cov-${CLANG_VERSION}" llvm-cov)
+
+    if(NOT LLVM_COV_EXECUTABLE)
+      message(FATAL_ERROR
+              "[${PROJECT_NAME}] - Coverage with Clang requires llvm-cov, install package llvm-${CLANG_VERSION}")
+    endif()
+
+    set(GCOV_TOOL "${LLVM_COV_EXECUTABLE} gcov")
+  else()
+    set(GCOV_TOOL "gcov")
+  endif()
+
+  set(COVERAGE_DIR "${PROJECT_BINARY_DIR}/coverage")
+
+  # Only the library itself is worth reporting on - the tests exercising it are not. The search path
+  # must stay on this build tree: --root alone lets gcovr wander into a sibling build made by
+  # another compiler, whose notes the local gcov refuses to read.
+  set(GCOVR_COMMAND ${GCOVR_EXECUTABLE}
+                    "${PROJECT_BINARY_DIR}"
+                    --root "${PROJECT_SOURCE_DIR}"
+                    --filter "${PROJECT_SOURCE_DIR}/include/tts/"
+                    --gcov-executable "${GCOV_TOOL}"
+                    --exclude-unreachable-branches
+                    --exclude-throw-branches
+                    --print-summary
+  )
+
+  add_custom_target( tts-coverage-report
+                     COMMAND ${CMAKE_COMMAND} -E make_directory "${COVERAGE_DIR}"
+                     COMMAND ${GCOVR_COMMAND}
+                             --html-details "${COVERAGE_DIR}/index.html"
+                             --json-summary "${COVERAGE_DIR}/summary.json"
+                             --json-summary-pretty
+                     WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
+                     COMMENT "[${PROJECT_NAME}] - Generating coverage report in ${COVERAGE_DIR}"
+                     VERBATIM
+                   )
+
+  add_custom_target( tts-coverage
+                     COMMAND ${CMAKE_COMMAND} -DCOVERAGE_BUILD_DIR=${PROJECT_BINARY_DIR}
+                                              -P "${PROJECT_SOURCE_DIR}/cmake/reset_coverage.cmake"
+                     COMMAND ${CMAKE_CTEST_COMMAND} --build-config $<CONFIG> --output-on-failure
+                     WORKING_DIRECTORY "${PROJECT_BINARY_DIR}"
+                     COMMENT "[${PROJECT_NAME}] - Running the test suite under coverage"
+                     VERBATIM
+                   )
+
+  add_dependencies(tts-coverage-report tts-coverage)
+  add_dependencies(tts-coverage tts-test)
+
+  message(STATUS "[${PROJECT_NAME}] - Coverage enabled for target '${target}' via ${GCOVR_EXECUTABLE}")
+endfunction()

--- a/cmake/reset_coverage.cmake
+++ b/cmake/reset_coverage.cmake
@@ -1,0 +1,15 @@
+##======================================================================================================================
+##  TTS - Tiny Test System
+##  Copyright : TTS Contributors & Maintainers
+##  SPDX-License-Identifier: BSL-1.0
+##======================================================================================================================
+## Drops the counters left by a previous run. Run via 'cmake -DCOVERAGE_BUILD_DIR=<dir> -P'.
+##
+## Counters accumulate across runs, and a rebuild leaves them stamped for object files that no
+## longer match, which gcov reports as an error rather than ignoring.
+##======================================================================================================================
+file(GLOB_RECURSE TTS_STALE_COUNTERS "${COVERAGE_BUILD_DIR}/*.gcda")
+
+if(TTS_STALE_COUNTERS)
+  file(REMOVE ${TTS_STALE_COUNTERS})
+endif()


### PR DESCRIPTION
Coverage is collected with gcovr and filtered down to `include/tts`, since the tests exercising the library are of no interest in the report themselves. `TTS_ENABLE_COVERAGE` instruments the test targets and stays off by default, with `gcc-coverage` and `clang-coverage` presets mirroring the sanitize ones. Building `tts-coverage-report` runs the suite then writes a browsable HTML report under the build tree, and the CI job publishes it as an artifact alongside a summary table. Nothing gates on a threshold for now.

Two details worth knowing. The gcovr search path is pinned to the current build tree, because `--root` alone lets it wander into a sibling build made by another compiler, whose notes the local gcov then refuses to read. And the Clang path looks for the version-suffixed `llvm-cov` first, as distributions commonly ship no unsuffixed one at all.

Also carries an unrelated one-liner spotted along the way: the Linux matrix invoked the test action twice, once plainly and once for MemCheck, so every entry replayed the entire suite before reaching MemCheck. The action already chains both, so a single call does it.