### PR TITLE
Give the coverage badge a URL GitHub has not cached empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/badge/license-BSL-green?style=plastic)](./LICENSE.md)
 [![Discord](https://img.shields.io/discord/692734675726237696?style=plastic)](https://discord.com/channels/692734675726237696/692735300522344468)
 [![CI Status](https://github.com/jfalcou/tts/actions/workflows/integration.yml/badge.svg)](https://github.com/jfalcou/tts/actions/workflows/integration.yml)
-[![Coverage](https://img.shields.io/endpoint?url=https://jfalcou.github.io/tts/coverage/badge.json&style=plastic)](https://jfalcou.github.io/tts/coverage/)
+[![Coverage](https://img.shields.io/endpoint?url=https://jfalcou.github.io/tts/coverage/badge.json&style=plastic&cacheSeconds=1800)](https://jfalcou.github.io/tts/coverage/)
 
 **Tiny Test System** is a C++20 open-source Unit Test library designed following the ideas of
 libraries like CATCH or LEST.


### PR DESCRIPTION
The badge landed on main a few minutes before the documentation workflow had pushed `badge.json` to gh-pages, so the first render found nothing and GitHub cached the "resource not found" image. Camo keys that cache on the URL, which is why refreshing never helped and why shields serves the right badge for the very same URL when asked directly.

Adding `cacheSeconds` mints a key GitHub has no entry for, and bounds how long any future miss can persist, so the badge follows a deployment within half an hour instead of sitting on a stale figure.