### PR TITLE
Move to copacabana v2

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -13,7 +13,7 @@ jobs:
   documentation:
     permissions:
       contents: write
-    uses: jfalcou/copacabana/.github/workflows/documentation.yml@184770e42deec34dc0cc39158960bb3acbbbd06e # v1
+    uses: jfalcou/copacabana/.github/workflows/documentation.yml@17df3f26736d3a0ecc231a3b951f548dcbc09c45 # v2
     with:
       project: tts
       coverage: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,6 +15,6 @@ concurrency:
 
 jobs:
   integration:
-    uses: jfalcou/copacabana/.github/workflows/integration.yml@184770e42deec34dc0cc39158960bb3acbbbd06e # v1
+    uses: jfalcou/copacabana/.github/workflows/integration.yml@17df3f26736d3a0ecc231a3b951f548dcbc09c45 # v2
     with:
       project: tts

--- a/.github/workflows/package-standalone.yml
+++ b/.github/workflows/package-standalone.yml
@@ -14,6 +14,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: jfalcou/copacabana/.github/workflows/package-standalone.yml@184770e42deec34dc0cc39158960bb3acbbbd06e # v1
+    uses: jfalcou/copacabana/.github/workflows/package-standalone.yml@17df3f26736d3a0ecc231a3b951f548dcbc09c45 # v2
     with:
       project: tts


### PR DESCRIPTION
v1's shared workflows added the safe.directory exception for the path the github.workspace expression resolves to, which is the host's, not the one the repository has inside the container. The standalone job died on dubious ownership the first time it ran on main; documentation and integration were unaffected, integration because nothing in it needs the exception.

Only the three references change. The standalone branch was never written to, so nothing needs undoing.