### PR TITLE
Pin every copacabana reference to v4

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -13,7 +13,7 @@ jobs:
   documentation:
     permissions:
       contents: write
-    uses: jfalcou/copacabana/.github/workflows/documentation.yml@17df3f26736d3a0ecc231a3b951f548dcbc09c45 # v2
+    uses: jfalcou/copacabana/.github/workflows/documentation.yml@3337f916bb581d0829909976773f7a2ee827a25c # v4
     with:
       project: tts
       coverage: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,6 +15,6 @@ concurrency:
 
 jobs:
   integration:
-    uses: jfalcou/copacabana/.github/workflows/integration.yml@17df3f26736d3a0ecc231a3b951f548dcbc09c45 # v2
+    uses: jfalcou/copacabana/.github/workflows/integration.yml@3337f916bb581d0829909976773f7a2ee827a25c # v4
     with:
       project: tts

--- a/.github/workflows/package-standalone.yml
+++ b/.github/workflows/package-standalone.yml
@@ -14,6 +14,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: jfalcou/copacabana/.github/workflows/package-standalone.yml@17df3f26736d3a0ecc231a3b951f548dcbc09c45 # v2
+    uses: jfalcou/copacabana/.github/workflows/package-standalone.yml@3337f916bb581d0829909976773f7a2ee827a25c # v4
     with:
       project: tts


### PR DESCRIPTION
documentation, integration and standalone were still on the pin they got when they were adopted, so the repository called copacabana at two different commits. Between those tags the three workflows only gained a full image reference where a bare tag was, and lost some comments.