### PR TITLE
Fix #224 - Keep the lower bound the caller asked for

### DIFF
--- a/include/tts/tools/random.hpp
+++ b/include/tts/tools/random.hpp
@@ -84,12 +84,27 @@ namespace tts
       return _::roll(mini, maxi);
     }
 
+    // The floor a log-uniform roll starts from, for a range entirely above zero. It only moves when
+    // mini is the placeholder rather than a bound the caller wrote: smvlp is what the zero-crossing
+    // branch recurses with, and what an explicit 0 becomes. Rolling from there up to 1 would
+    // practically never come near 1, hence the lift. A bound the caller asked for is the range they
+    // want tested, so it stays.
+    template<std::floating_point T> T rolling_floor(T mini, T maxi)
+    {
+      constexpr T smvlp = std::numeric_limits<T>::min();
+      constexpr T eps   = std::numeric_limits<T>::epsilon();
+
+      if(mini != smvlp) return mini;
+      if(maxi == 1) return eps;
+      if(maxi > 1) return max(T(1) / _::sqrt(maxi), mini);
+      return mini;
+    }
+
     // Floating point complex logic (Logarithmic distribution)
     template<std::floating_point T> T roll_random(T mini, T maxi)
     {
       constexpr T smvlp     = std::numeric_limits<T>::min();
       constexpr T valmax    = std::numeric_limits<T>::max();
-      constexpr T eps       = std::numeric_limits<T>::epsilon();
       constexpr T quiet_nan = std::numeric_limits<T>::quiet_NaN();
 
       // Degenerate range: the only value in [mini,maxi] is mini itself
@@ -122,8 +137,7 @@ namespace tts
       // Handle Single-Sided Ranges
       if(mini > 0)
       {
-        if(mini < 1 && maxi > 1) mini = max(T(1) / _::sqrt(maxi), mini);
-        mini      = (maxi == 1) ? eps : mini;
+        mini      = rolling_floor(mini, maxi);
 
         T log_min = _::log10(mini);
         T log_max = _::log10(maxi);
@@ -134,9 +148,8 @@ namespace tts
       }
       else if(maxi < 0)
       {
-        // Mirror logic for negatives
-        if(mini < -1 && maxi > -1) maxi = min(T(1) / _::sqrt(-mini), maxi);
-        maxi      = (mini == -1) ? -eps : maxi;
+        // Mirrored: the same floor, applied to the magnitudes.
+        maxi      = -rolling_floor(-maxi, -mini);
 
         T log_min = _::log10(-maxi);
         T log_max = _::log10(-mini);


### PR DESCRIPTION
The two floor adjustments in `roll_random` exist for the placeholder the zero-crossing branch recurses with, where a log-uniform draw from the smallest normal up to 1 would practically never come near 1. Applied to a bound the caller wrote, they discard the range that was asked to be tested: `randoms(0.01, 1.0)` drew down to 1e-12 in double. Guarding both on `mini == smvlp` keeps the heuristic where it belongs.

The mirror branch had the same defect for ranges entirely below zero.