### PR TITLE
Move to copacabana v8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
   ##################################################################################################
   precommit:
     name: Meta Checks
-    uses: jfalcou/copacabana/.github/workflows/precommit.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/precommit.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
 
   ##======================================================================================================================
   ## Ensure Standalone is viable
@@ -49,14 +49,14 @@ jobs:
   ##################################################################################################
   sanitizer-tests:
     name: Sanitizers
-    uses: jfalcou/copacabana/.github/workflows/sanitizers.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/sanitizers.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
 
   ##################################################################################################
   ## Coverage report - informational, runs alongside the gate without blocking the matrix
   ##################################################################################################
   coverage-report:
     name: Coverage
-    uses: jfalcou/copacabana/.github/workflows/coverage.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/coverage.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       project: tts
 
@@ -66,27 +66,27 @@ jobs:
   linux-tests:
     name: Linux
     needs: [precommit, standalone-generation, sanitizer-tests]
-    uses: jfalcou/copacabana/.github/workflows/matrix.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/matrix.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       file: .github/matrices/linux.yml
 
   macos-tests:
     name: MacOS
     needs: [precommit, standalone-generation, sanitizer-tests]
-    uses: jfalcou/copacabana/.github/workflows/matrix.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/matrix.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       file: .github/matrices/macos.yml
 
   windows-tests:
     name: Windows
     needs: [precommit, standalone-generation, sanitizer-tests]
-    uses: jfalcou/copacabana/.github/workflows/matrix.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/matrix.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       file: .github/matrices/windows.yml
 
   nvidia-tests:
     name: Nvidia
     needs: [precommit, standalone-generation, sanitizer-tests]
-    uses: jfalcou/copacabana/.github/workflows/matrix.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/matrix.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       file: .github/matrices/nvidia.yml

--- a/.github/workflows/compile-cost.yml
+++ b/.github/workflows/compile-cost.yml
@@ -23,6 +23,6 @@ jobs:
     permissions:
       actions: read
       contents: read
-    uses: jfalcou/copacabana/.github/workflows/compile-cost.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/compile-cost.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       project: tts

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -17,7 +17,7 @@ jobs:
   documentation:
     permissions:
       contents: write
-    uses: jfalcou/copacabana/.github/workflows/documentation.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/documentation.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       project: tts
       coverage: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,6 +15,6 @@ concurrency:
 
 jobs:
   integration:
-    uses: jfalcou/copacabana/.github/workflows/integration.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/integration.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       project: tts

--- a/.github/workflows/package-standalone.yml
+++ b/.github/workflows/package-standalone.yml
@@ -14,6 +14,6 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: jfalcou/copacabana/.github/workflows/package-standalone.yml@05d0796125e284daa16d9a4f6424c58f98a2bb5a # v7
+    uses: jfalcou/copacabana/.github/workflows/package-standalone.yml@44053e713b1b57329ccbcbb8878c839024bf19ee # v8
     with:
       project: tts

--- a/cmake/dependencies.cmake
+++ b/cmake/dependencies.cmake
@@ -12,4 +12,4 @@ include(${CMAKE_CURRENT_LIST_DIR}/CPM.cmake)
 ##======================================================================================================================
 ## Retrieve dependencies
 ##======================================================================================================================
-CPMAddPackage(NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana GIT_TAG v7)
+CPMAddPackage(NAME COPACABANA GITHUB_REPOSITORY jfalcou/copacabana GIT_TAG v8)


### PR DESCRIPTION
The matrix ran no test from v7 on: a row saying nothing about test read as null, which GitHub compares equal to false. This pin is what brings the tests back, so the jobs of this repository run them again for the first time since 2026-09-03.