### PR TITLE
Run the unit matrix on a nightly schedule and align the badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@
 ##======================================================================================================================
 name: Unit Tests
 on:
+  ## Main gets the matrix once a night rather than on every merge: a run of its own queued behind each merge held
+  ## the pull requests back. 01:20 UTC, which is 02:20 in Paris in winter, and off the hour that every other
+  ## scheduled workflow on the platform asks for.
+  schedule:
+    - cron: '20 1 * * *'
   pull_request:
     branches:
       - main

--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 # The TTS Library
 
+[![Release](https://img.shields.io/github/v/release/jfalcou/tts?style=plastic&label=release)](https://github.com/jfalcou/tts/releases/latest)
 [![License](https://img.shields.io/badge/license-BSL-green?style=plastic)](./LICENSE.md)
 [![Discord](https://img.shields.io/discord/692734675726237696?style=plastic)](https://discord.com/channels/692734675726237696/692735300522344468)
-[![CI Status](https://github.com/jfalcou/tts/actions/workflows/integration.yml/badge.svg)](https://github.com/jfalcou/tts/actions/workflows/integration.yml)
+[![Integration](https://github.com/jfalcou/tts/actions/workflows/integration.yml/badge.svg)](https://github.com/jfalcou/tts/actions/workflows/integration.yml)
 [![Coverage](https://img.shields.io/endpoint?url=https://jfalcou.github.io/tts/coverage/badge.json&style=plastic&cacheSeconds=1800)](https://jfalcou.github.io/tts/coverage/)
+[![CI](https://github.com/jfalcou/tts/actions/workflows/ci.yml/badge.svg?event=schedule)](https://github.com/jfalcou/tts/actions/workflows/ci.yml?query=event%3Aschedule)
 
 **Tiny Test System** is a C++20 open-source Unit Test library designed following the ideas of
 libraries like CATCH or LEST.


### PR DESCRIPTION
Aligns tts on the layout kumi settled in its PR 251. The unit matrix now also runs on a schedule at
01:20 UTC, so a broken main shows up the next morning instead of behind a queue of pull requests.
The push trigger on main stays where it belongs, in compile-cost.yml, whose single job deposits the
reference that pull requests subtract.

The README carries the six badges in kumi's order. The last one reads ci.yml filtered on
?event=schedule, so it reports the nightly run and never a pull request. Integration was labelled CI
Status while pointing at integration.yml, and the release badge was absent.
