### PR TITLE
Give every navigation tab a page of its own

### DIFF
--- a/doc/layout.xml
+++ b/doc/layout.xml
@@ -3,19 +3,19 @@
   <!-- Navigation index tabs for HTML output -->
   <navindex>
     <tab type="mainpage" visible="yes" title=""/>
-    <tab type="usergroup" visible="yes" title="How-Tos">
+    <tab type="usergroup" visible="yes" title="How-Tos" url="@ref setup">
       <tab type="user" url="@ref setup"   title="Setup"/>
       <tab type="user" url="@ref tts101"  title="Getting Started"/>
       <tab type="user" url="@ref cli"     title="Command Line Interface"/>
       <tab type="user" url="@ref output-sinks" title="Built-in Output Sinks"/>
-      <tab type="usergroup" visible="yes" title="Customizing TTS">
+      <tab type="usergroup" visible="yes" title="Customizing TTS" url="@ref customize">
         <tab type="user" url="@ref customize"               title="General Behaviour"/>
         <tab type="user" url="@ref tools-generators-custom" title="Generators"/>
         <tab type="user" url="@ref customization-points"    title="Other Customizations"/>
       </tab>
     </tab>
-    <tab type="usergroup" visible="yes"     title="Reference Documentation">
-      <tab type="usergroup" visible="yes"   title="Testing Macros">
+    <tab type="usergroup" visible="yes"     title="Reference Documentation" url="@ref tts_reference">
+      <tab type="usergroup" visible="yes"   title="Testing Macros" url="@ref test-scenario">
         <tab type="user" url="@ref test-scenario"   title="Scenario Definition"/>
         <tab type="user" url="@ref test-basic"      title="Basic Tests"/>
         <tab type="user" url="@ref test-relation"   title="Relation Tests"/>
@@ -24,7 +24,7 @@
         <tab type="user" url="@ref test-exceptions" title="Exceptions Tests"/>
         <tab type="user" url="@ref test-types"      title="Type Tests"/>
       </tab>
-      <tab type="usergroup" visible="yes" title="Tools and Helpers" intro="">
+      <tab type="usergroup" visible="yes" title="Tools and Helpers" intro="" url="@ref tools-config">
         <tab type="user" url="@ref tools-config"            title="Configuration"/>
         <tab type="user" url="@ref tools-generators-class"  title="Data Generators"/>
         <tab type="user" url="@ref tools-output"            title="Output Utilities"/>
@@ -34,7 +34,7 @@
         <tab type="user" url="@ref tools-types"             title="Type Utilities"/>
       </tab>
     </tab>
-    <tab type="usergroup" visible="yes" title="Informations">
+    <tab type="usergroup" visible="yes" title="Informations" url="@ref rationale">
        <tab type="user" url="@ref rationale" title="Rationale"/>
        <tab type="user" url="@ref compile-time" title="Compile-Time Discipline"/>
        <tab type="user" url="@ref changelog" title="Changelog"/>

--- a/doc/reference.hpp
+++ b/doc/reference.hpp
@@ -1,0 +1,28 @@
+#error This file is for documentation only - DO NOT INCLUDE
+/**
+
+  @page tts_reference Reference Documentation
+
+  Every macro, tool and helper the library exposes, gathered by role.
+
+  ### Testing Macros
+
+  - @ref test-scenario
+  - @ref test-basic
+  - @ref test-relation
+  - @ref test-precision
+  - @ref test-sequence
+  - @ref test-exceptions
+  - @ref test-types
+
+  ### Tools and Helpers
+
+  - @ref tools-config
+  - @ref tools-generators-class
+  - @ref tools-output
+  - @ref tools-precision
+  - @ref tools-random
+  - @ref tools-text
+  - @ref tools-types
+
+**/

--- a/doc/tutorial.hpp
+++ b/doc/tutorial.hpp
@@ -65,6 +65,6 @@
   @endcode
 
   One may notice that no other information is displayed. This is the default behaviour.
-  You can now use [the various **TTS** testing macros](usergroup2.html) to design your own unit tests.
+  You can now use [the various **TTS** testing macros](@ref tts_reference) to design your own unit tests.
 **/
 //==================================================================================================


### PR DESCRIPTION
A container tab carrying no `url` is served as `usergroupN.html`, numbered by position, so inserting an entry moves what an existing link points to. The tutorial had `usergroup2.html` written by hand, which is the failure itself; it now names `@ref tts_reference`, a page that gathers the macro and tool groups, the way kumi settled it in jfalcou/kumi#251.

The commit is marked `[no ci]`, so nothing reports and the barrier never lifts. The documentation was rebuilt locally in its place: no doxygen warning, so no reference dangles, and no `usergroup*.html` is left in the output.
