### PR TITLE
Fix #202 - Attribute a crash to the test case that caused it

### DIFF
--- a/doc/customisation.hpp
+++ b/doc/customisation.hpp
@@ -21,6 +21,22 @@
 
   @snippet doc/entry_point.cpp snippet
 
+  @section customize-abort Crashed and Stuck Runs
+  A crashed test case cannot resume, so **TTS** names it, reports it through the sinks and exits
+  with 1. @ref tts::set_abort_handler runs just before that exit, with the signal that brought the
+  run down or `0` when nothing did.
+
+  A test binary that has to handle an abrupt stop in its own way installs one.
+
+  @snippet doc/abort_handler.cpp snippet
+
+  The guard covers `SIGSEGV`, `SIGBUS`, `SIGFPE`, `SIGILL` and `SIGABRT`, that last one catching an
+  `assert` in the code under test; under Windows, access violations, stack overflows, integer
+  divisions by zero and illegal instructions. Under emscripten it is compiled out.
+
+  `--no-crash-guard`, or `TTS_NO_CRASH_GUARD` in the environment, leaves those signals to the
+  system: that is what a debugger, or a sanitizer stack trace, needs.
+
   @section  customize-display Data display
   By default, whenever **TTS** needs to display a value in a report, it uses `std::to_string`
   or, in the case of sequence-like types, a sequence of calls to `std::to_string`. In case no

--- a/include/tts/engine/abort.hpp
+++ b/include/tts/engine/abort.hpp
@@ -1,0 +1,117 @@
+//======================================================================================================================
+//! @file
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//======================================================================================================================
+#pragma once
+
+#include <tts/engine/deps.hpp>
+#include <tts/tools/callable.hpp>
+#include <tts/tools/erased_storage.hpp>
+
+namespace tts::_
+{
+  struct abort_handler : erased_storage
+  {
+    using signature_t = void (*)(void*, int);
+
+    abort_handler()   = default;
+
+    abort_handler(void (*f)(int))                                       // NOSONAR
+        : erased_storage {reinterpret_cast<void*>(f), &destroy_nothing} // NOSONAR Type erasure
+        , invoker {invoke_ptr}
+    {
+    }
+
+    template<typename Function>
+    abort_handler(Function f)                                             // NOSONAR
+        : erased_storage {new Function {TTS_MOVE(f)}, &destroy<Function>} // NOSONAR Type erasure
+        , invoker {invoke<Function>}
+    {
+    }
+
+    abort_handler(abort_handler&& other) noexcept
+        : erased_storage {TTS_MOVE(other)}
+        , invoker {other.invoker}
+    {
+    }
+
+    abort_handler& operator=(abort_handler&& other) noexcept
+    {
+      erased_storage::operator=(TTS_MOVE(other));
+      invoker = other.invoker;
+      return *this;
+    }
+
+    void operator()(int reason) const
+    {
+      assert(payload);
+      invoker(payload, reason);
+    }
+
+    signature_t invoker = nullptr;
+
+  private:
+    template<typename T> static void invoke(void* data, int reason) // NOSONAR Type erasure
+    {
+      (*static_cast<T*>(data))(reason);
+    }
+
+    static void invoke_ptr(void* data, int reason) // NOSONAR Type erasure
+    {
+      reinterpret_cast<void (*)(int)>(data)(reason); // NOSONAR Type erasure
+    }
+  };
+
+  inline callable          abort_epilogue = {};
+  inline abort_handler     abort_action   = {};
+
+  [[noreturn]] inline void exit_now()
+  {
+    // No atexit handler and no static destructor may run on a half-finished case, and _Exit
+    // flushes nothing.
+    fflush(stdout);
+    fflush(stderr);
+    std::_Exit(1);
+  }
+
+  [[noreturn]] inline void perform_abort(int reason)
+  {
+    if(abort_epilogue) abort_epilogue();
+    if(abort_action) abort_action(reason);
+    exit_now();
+  }
+}
+
+namespace tts
+{
+  //====================================================================================================================
+  /**
+    @brief Run termination customization point
+    @ingroup customization-points
+
+    Runs just before **TTS** exits a crashed or timed out run, with the signal that brought it down
+    or `0` when nothing did. **TTS** exits with 1 once it returns.
+
+    Useful when a test binary has to handle an abrupt stop in its own way.
+
+    @param h  Any callable taking an `int`.
+
+    @return The handler installed before this call, empty if there was none.
+
+    @see TTS_CUSTOM_DRIVER_FUNCTION
+
+    @groupheader{Example}
+    @snippet doc/abort_handler.cpp snippet
+  **/
+  //====================================================================================================================
+  template<typename Handler> inline _::abort_handler set_abort_handler(Handler h)
+  {
+    _::abort_handler previous = TTS_MOVE(_::abort_action);
+    _::abort_action           = _::abort_handler {TTS_MOVE(h)};
+    return previous;
+  }
+}

--- a/include/tts/engine/abort.hpp
+++ b/include/tts/engine/abort.hpp
@@ -46,6 +46,8 @@ namespace tts::_
       return *this;
     }
 
+    ~abort_handler() = default;
+
     void operator()(int reason) const
     {
       assert(payload);
@@ -66,8 +68,8 @@ namespace tts::_
     }
   };
 
-  inline callable          abort_epilogue = {};
-  inline abort_handler     abort_action   = {};
+  inline callable          abort_epilogue = {}; // NOSONAR - the driver sets it once it is ready
+  inline abort_handler     abort_action   = {}; // NOSONAR - set_abort_handler replaces it
 
   [[noreturn]] inline void exit_now()
   {

--- a/include/tts/engine/abort.hpp
+++ b/include/tts/engine/abort.hpp
@@ -14,7 +14,7 @@
 
 namespace tts::_
 {
-  struct abort_handler : erased_storage
+  struct abort_handler : erased_storage // NOSONAR - erased_storage owns the payload and destroys it
   {
     using signature_t = void (*)(void*, int);
 
@@ -45,8 +45,6 @@ namespace tts::_
       invoker = other.invoker;
       return *this;
     }
-
-    ~abort_handler() = default;
 
     void operator()(int reason) const
     {

--- a/include/tts/engine/guard.hpp
+++ b/include/tts/engine/guard.hpp
@@ -1,0 +1,204 @@
+//======================================================================================================================
+//! @file
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//======================================================================================================================
+#pragma once
+
+#include <tts/engine/abort.hpp>
+#include <tts/engine/environment.hpp>
+#include <tts/engine/test.hpp>
+
+#if defined(__EMSCRIPTEN__)
+#elif defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#include <windows.h>
+#include <csignal>
+#else
+#include <csignal>
+#endif
+
+namespace tts::_
+{
+  inline std::size_t remaining_tests = 0;
+
+  // Read once: a debugger or a sanitizer wants the signal for itself.
+  inline bool crash_guard_enabled()
+  {
+    static bool that = !::tts::arguments()("--no-crash-guard");
+    return that;
+  }
+
+  // Not async-signal-safe: each handler guards its own re-entry before calling this.
+  inline void report_crash(char const* cause, void const* address)
+  {
+    // Without this the Results: line reads 100% success on a run that died.
+    ::tts::global_runtime.fatal();
+    ::tts::global_runtime.unexpected();
+
+    if(address)
+      ::tts::output().writeln("TEST: '%s' - @@ CRASHED @@ %s at %p", current_test, cause, address);
+    else ::tts::output().writeln("TEST: '%s' - @@ CRASHED @@ %s", current_test, cause);
+
+    ::tts::output().suite_aborted();
+    ::tts::output().writeln("@@ ABORTING DUE TO CRASH @@ - %d Tests not run",
+                            static_cast<int>(remaining_tests));
+
+    ::tts::report(0, 0);
+    ::tts::output().finish();
+  }
+}
+
+#if defined(__EMSCRIPTEN__)
+namespace tts::_
+{
+  // No process-wide signal delivery here: nothing to arm.
+  struct crash_guard
+  {
+  };
+}
+#elif defined(_WIN32)
+namespace tts::_
+{
+  inline LONG WINAPI crash_filter(PEXCEPTION_POINTERS info)
+  {
+    auto        code  = info->ExceptionRecord->ExceptionCode;
+
+    char const* cause = nullptr;
+    switch(code)
+    {
+    case EXCEPTION_ACCESS_VIOLATION: cause = "access violation"; break;
+    case EXCEPTION_STACK_OVERFLOW: cause = "stack overflow"; break;
+    case EXCEPTION_INT_DIVIDE_BY_ZERO: cause = "integer divide by zero"; break;
+    case EXCEPTION_ILLEGAL_INSTRUCTION: cause = "illegal instruction"; break;
+    default: return EXCEPTION_CONTINUE_SEARCH;
+    }
+
+    static bool reporting = false;
+    if(reporting) exit_now();
+    reporting = true;
+
+    report_crash(cause, info->ExceptionRecord->ExceptionAddress);
+    perform_abort(static_cast<int>(code));
+  }
+
+  extern "C" inline void crash_on_abort_signal(int)
+  {
+    static bool reporting = false;
+    if(reporting) exit_now();
+    reporting = true;
+
+    report_crash("SIGABRT", nullptr);
+    perform_abort(SIGABRT);
+  }
+
+  struct crash_guard
+  {
+    crash_guard()
+    {
+      if(!armed_) return;
+
+      // The stack overflow exception needs this reserve to be delivered at all.
+      ULONG guarantee = 64u * 1024u;
+      SetThreadStackGuarantee(&guarantee);
+
+      handle_   = AddVectoredExceptionHandler(1, &crash_filter);
+      previous_ = signal(SIGABRT, &crash_on_abort_signal);
+    }
+
+    ~crash_guard()
+    {
+      if(!armed_) return;
+
+      if(handle_) RemoveVectoredExceptionHandler(handle_);
+      if(previous_ != SIG_ERR) signal(SIGABRT, previous_);
+    }
+
+    crash_guard(crash_guard const&)            = delete;
+    crash_guard& operator=(crash_guard const&) = delete;
+
+    PVOID        handle_                       = nullptr;
+    void (*previous_)(int)                     = SIG_ERR;
+    bool armed_                                = crash_guard_enabled();
+  };
+}
+#else
+namespace tts::_
+{
+  inline constexpr int crash_signals[] = {SIGSEGV, SIGBUS, SIGFPE, SIGILL, SIGABRT};
+
+  inline char const*   signal_name(int sig)
+  {
+    switch(sig)
+    {
+    case SIGSEGV: return "SIGSEGV";
+    case SIGBUS: return "SIGBUS";
+    case SIGFPE: return "SIGFPE";
+    case SIGILL: return "SIGILL";
+    case SIGABRT: return "SIGABRT";
+    default: return "signal";
+    }
+  }
+
+  extern "C" inline void crash_handler(int sig, siginfo_t* info, void*)
+  {
+    static sig_atomic_t volatile reporting = 0;
+    if(reporting)
+    {
+      signal(sig, SIG_DFL);
+      raise(sig);
+      exit_now();
+    }
+    reporting = 1;
+
+    report_crash(signal_name(sig), sig == SIGABRT ? nullptr : info->si_addr);
+    perform_abort(sig);
+  }
+
+  struct crash_guard
+  {
+    crash_guard()
+    {
+      if(!armed_) return;
+
+      // A stack overflow leaves no stack for the handler to run on, hence the alternate one.
+      stack_t alt  = {};
+      alt.ss_sp    = stack_;
+      alt.ss_size  = sizeof(stack_);
+      alt.ss_flags = 0;
+      sigaltstack(&alt, nullptr);
+
+      struct sigaction action = {};
+      action.sa_sigaction     = &crash_handler;
+      action.sa_flags         = SA_SIGINFO | SA_ONSTACK;
+      sigemptyset(&action.sa_mask);
+
+      for(std::size_t i = 0; i < sizeof(crash_signals) / sizeof(int); ++i)
+        sigaction(crash_signals[ i ], &action, &previous_[ i ]);
+    }
+
+    ~crash_guard()
+    {
+      if(!armed_) return;
+
+      for(std::size_t i = 0; i < sizeof(crash_signals) / sizeof(int); ++i)
+        sigaction(crash_signals[ i ], &previous_[ i ], nullptr);
+    }
+
+    crash_guard(crash_guard const&)            = delete;
+    crash_guard& operator=(crash_guard const&) = delete;
+
+  private:
+    // SIGSTKSZ stopped being a constant in glibc 2.34, so the alternate stack has a fixed size.
+    static constexpr std::size_t alt_stack_size                                   = 64u * 1024u;
+
+    static inline char           stack_[ alt_stack_size ]                         = {};
+    struct sigaction             previous_[ sizeof(crash_signals) / sizeof(int) ] = {};
+    bool                         armed_ = crash_guard_enabled();
+  };
+}
+#endif

--- a/include/tts/engine/guard.hpp
+++ b/include/tts/engine/guard.hpp
@@ -11,6 +11,7 @@
 #include <tts/engine/abort.hpp>
 #include <tts/engine/environment.hpp>
 #include <tts/engine/test.hpp>
+#include <array>
 
 #if defined(__EMSCRIPTEN__)
 #elif defined(_WIN32)
@@ -24,7 +25,7 @@
 
 namespace tts::_
 {
-  inline std::size_t remaining_tests = 0;
+  inline std::size_t remaining_tests = 0; // NOSONAR - the loop updates it before each case
 
   // Read once: a debugger or a sanitizer wants the signal for itself.
   inline bool crash_guard_enabled()
@@ -34,7 +35,7 @@ namespace tts::_
   }
 
   // Not async-signal-safe: each handler guards its own re-entry before calling this.
-  inline void report_crash(char const* cause, void const* address)
+  inline void report_crash(char const* cause, void const* address) // NOSONAR - an address is void*
   {
     // Without this the Results: line reads 100% success on a run that died.
     ::tts::global_runtime.fatal();
@@ -86,16 +87,23 @@ namespace tts::_
     perform_abort(static_cast<int>(code));
   }
 
-  extern "C" inline void crash_on_abort_signal(int)
+}
+
+extern "C"
+{
+  [[noreturn]] inline void tts_crash_on_abort_signal(int)
   {
     static bool reporting = false;
-    if(reporting) exit_now();
+    if(reporting) ::tts::_::exit_now();
     reporting = true;
 
-    report_crash("SIGABRT", nullptr);
-    perform_abort(SIGABRT);
+    ::tts::_::report_crash("SIGABRT", nullptr);
+    ::tts::_::perform_abort(SIGABRT);
   }
+}
 
+namespace tts::_
+{
   struct crash_guard
   {
     crash_guard()
@@ -107,7 +115,7 @@ namespace tts::_
       SetThreadStackGuarantee(&guarantee);
 
       handle_   = AddVectoredExceptionHandler(1, &crash_filter);
-      previous_ = signal(SIGABRT, &crash_on_abort_signal);
+      previous_ = signal(SIGABRT, &tts_crash_on_abort_signal);
     }
 
     ~crash_guard()
@@ -129,9 +137,9 @@ namespace tts::_
 #else
 namespace tts::_
 {
-  inline constexpr int crash_signals[] = {SIGSEGV, SIGBUS, SIGFPE, SIGILL, SIGABRT};
+  inline constexpr std::array<int, 5> crash_signals {SIGSEGV, SIGBUS, SIGFPE, SIGILL, SIGABRT};
 
-  inline char const*   signal_name(int sig)
+  inline char const*                  signal_name(int sig)
   {
     switch(sig)
     {
@@ -144,21 +152,30 @@ namespace tts::_
     }
   }
 
-  extern "C" inline void crash_handler(int sig, siginfo_t* info, void*)
+}
+
+extern "C"
+{
+  // sigaction hands a mutable siginfo_t, so this parameter cannot take a const.
+  [[noreturn]] inline void
+  tts_crash_handler(int sig, siginfo_t* info, void*) // NOSONAR - the kernel picks this signature
   {
     static sig_atomic_t volatile reporting = 0;
     if(reporting)
     {
       signal(sig, SIG_DFL);
       raise(sig);
-      exit_now();
+      ::tts::_::exit_now();
     }
     reporting = 1;
 
-    report_crash(signal_name(sig), sig == SIGABRT ? nullptr : info->si_addr);
-    perform_abort(sig);
+    ::tts::_::report_crash(::tts::_::signal_name(sig), sig == SIGABRT ? nullptr : info->si_addr);
+    ::tts::_::perform_abort(sig);
   }
+}
 
+namespace tts::_
+{
   struct crash_guard
   {
     crash_guard()
@@ -167,17 +184,17 @@ namespace tts::_
 
       // A stack overflow leaves no stack for the handler to run on, hence the alternate one.
       stack_t alt  = {};
-      alt.ss_sp    = stack_;
-      alt.ss_size  = sizeof(stack_);
+      alt.ss_sp    = stack_.data();
+      alt.ss_size  = stack_.size();
       alt.ss_flags = 0;
       sigaltstack(&alt, nullptr);
 
       struct sigaction action = {};
-      action.sa_sigaction     = &crash_handler;
+      action.sa_sigaction     = &tts_crash_handler;
       action.sa_flags         = SA_SIGINFO | SA_ONSTACK;
       sigemptyset(&action.sa_mask);
 
-      for(std::size_t i = 0; i < sizeof(crash_signals) / sizeof(int); ++i)
+      for(std::size_t i = 0; i < crash_signals.size(); ++i)
         sigaction(crash_signals[ i ], &action, &previous_[ i ]);
     }
 
@@ -185,7 +202,7 @@ namespace tts::_
     {
       if(!armed_) return;
 
-      for(std::size_t i = 0; i < sizeof(crash_signals) / sizeof(int); ++i)
+      for(std::size_t i = 0; i < crash_signals.size(); ++i)
         sigaction(crash_signals[ i ], &previous_[ i ], nullptr);
     }
 
@@ -194,11 +211,11 @@ namespace tts::_
 
   private:
     // SIGSTKSZ stopped being a constant in glibc 2.34, so the alternate stack has a fixed size.
-    static constexpr std::size_t alt_stack_size                                   = 64u * 1024u;
+    static constexpr std::size_t                       alt_stack_size = 64u * 1024u;
 
-    static inline char           stack_[ alt_stack_size ]                         = {};
-    struct sigaction             previous_[ sizeof(crash_signals) / sizeof(int) ] = {};
-    bool                         armed_ = crash_guard_enabled();
+    static inline std::array<char, alt_stack_size>     stack_ {};
+    std::array<struct sigaction, crash_signals.size()> previous_ {};
+    bool                                               armed_ = crash_guard_enabled();
   };
 }
 #endif

--- a/include/tts/engine/guard.hpp
+++ b/include/tts/engine/guard.hpp
@@ -87,18 +87,32 @@ namespace tts::_
     perform_abort(static_cast<int>(code));
   }
 
+  // The vectored handler never sees a raised signal, so the CRT dispositions cover them too.
+  inline constexpr std::array<int, 4> crash_signals {SIGSEGV, SIGFPE, SIGILL, SIGABRT};
+
+  inline char const*                  signal_name(int sig)
+  {
+    switch(sig)
+    {
+    case SIGSEGV: return "SIGSEGV";
+    case SIGFPE: return "SIGFPE";
+    case SIGILL: return "SIGILL";
+    case SIGABRT: return "SIGABRT";
+    default: return "signal";
+    }
+  }
 }
 
 extern "C"
 {
-  [[noreturn]] inline void tts_crash_on_abort_signal(int)
+  [[noreturn]] inline void tts_crash_on_signal(int sig)
   {
     static bool reporting = false;
     if(reporting) ::tts::_::exit_now();
     reporting = true;
 
-    ::tts::_::report_crash("SIGABRT", nullptr);
-    ::tts::_::perform_abort(SIGABRT);
+    ::tts::_::report_crash(::tts::_::signal_name(sig), nullptr);
+    ::tts::_::perform_abort(sig);
   }
 }
 
@@ -114,8 +128,10 @@ namespace tts::_
       ULONG guarantee = 64u * 1024u;
       SetThreadStackGuarantee(&guarantee);
 
-      handle_   = AddVectoredExceptionHandler(1, &crash_filter);
-      previous_ = signal(SIGABRT, &tts_crash_on_abort_signal);
+      handle_ = AddVectoredExceptionHandler(1, &crash_filter);
+
+      for(std::size_t i = 0; i < crash_signals.size(); ++i)
+        previous_[ i ] = signal(crash_signals[ i ], &tts_crash_on_signal);
     }
 
     ~crash_guard()
@@ -123,15 +139,17 @@ namespace tts::_
       if(!armed_) return;
 
       if(handle_) RemoveVectoredExceptionHandler(handle_);
-      if(previous_ != SIG_ERR) signal(SIGABRT, previous_);
+
+      for(std::size_t i = 0; i < crash_signals.size(); ++i)
+        if(previous_[ i ] && previous_[ i ] != SIG_ERR) signal(crash_signals[ i ], previous_[ i ]);
     }
 
-    crash_guard(crash_guard const&)            = delete;
-    crash_guard& operator=(crash_guard const&) = delete;
+    crash_guard(crash_guard const&)                                               = delete;
+    crash_guard&                                    operator=(crash_guard const&) = delete;
 
-    PVOID        handle_                       = nullptr;
-    void (*previous_)(int)                     = SIG_ERR;
-    bool armed_                                = crash_guard_enabled();
+    PVOID                                           handle_                       = nullptr;
+    std::array<void (*)(int), crash_signals.size()> previous_                     = {};
+    bool                                            armed_ = crash_guard_enabled();
   };
 }
 #else

--- a/include/tts/engine/main.hpp
+++ b/include/tts/engine/main.hpp
@@ -76,7 +76,7 @@ namespace tts::_
 #endif
 
 #if defined(TTS_MAIN)
-#include <tts/engine/guard.hpp>
+#include <tts/engine/guard.hpp> // NOSONAR - the driver is the only unit that needs the signals
 
 //======================================================================================================================
 // Outlined reporting functions implementations

--- a/include/tts/engine/main.hpp
+++ b/include/tts/engine/main.hpp
@@ -8,6 +8,7 @@
 //======================================================================================================================
 #pragma once
 
+#include <tts/engine/abort.hpp>
 #include <tts/engine/usage.hpp>
 #include <tts/engine/logger.hpp>
 #include <tts/engine/test.hpp>
@@ -75,6 +76,8 @@ namespace tts::_
 #endif
 
 #if defined(TTS_MAIN)
+#include <tts/engine/guard.hpp>
+
 //======================================================================================================================
 // Outlined reporting functions implementations
 //======================================================================================================================
@@ -208,6 +211,18 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
                             nb_tests,
                             nb_tests > 1 ? "s" : "");
 
+  // perform_abort() never returns here, so the capture file is flushed from there.
+  ::tts::_::abort_epilogue =
+  ::tts::_::callable {[ &capture_file, &capture_sink ]()
+                      {
+                        if(capture_file)
+                        {
+                          ::tts::output().sink(::tts::output_handler::default_sink());
+                          fputs(capture_sink.content().data(),
+                                capture_file.get()); // NOSONAR
+                        }
+                      }};
+
   try
   {
     std::size_t position = 0;
@@ -224,9 +239,14 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
       if(!::tts::is_quiet()) ::tts::output().writeln("TEST: '%s'", t.name);
       ::tts::output().flush();
 
+      ::tts::_::remaining_tests = nb_tests - done_tests - 1;
+
       // Always measured regardless of --verbose - sinks and the Total Time: line need it either way.
       auto start_ns = ::tts::_::now_ns();
-      t();
+      {
+        [[maybe_unused]] ::tts::_::crash_guard guard {};
+        t();
+      }
       auto duration_ns = ::tts::_::now_ns() - start_ns;
       done_tests++;
 

--- a/include/tts/engine/usage.hpp
+++ b/include/tts/engine/usage.hpp
@@ -19,6 +19,7 @@ Flags:
   -q, --quiet       Display only test failures percentage.
   --allow-empty     Do not fail when the test suite registered zero test.
   --dry             Print registered test names without running them.
+  --no-crash-guard  Leave a crash to the system instead of naming the case that caused it.
 
 Parameters:
   --precision=arg   Set the precision for displaying floating pint values

--- a/include/tts/tools/callable.hpp
+++ b/include/tts/tools/callable.hpp
@@ -7,86 +7,53 @@
 //======================================================================================================================
 #pragma once
 
+#include <tts/tools/erased_storage.hpp>
 #include <tts/tools/preprocessor.hpp>
 
 namespace tts::_
 {
-  struct callable
+  struct callable : erased_storage
   {
-  public:
-    using signature_t   = void (*)(void*);
+    using signature_t = void (*)(void*);
 
-    signature_t invoker = {}; // Type erased invoke call functions
-    signature_t cleanup = {}; // Type erased cleanup of payload
-    void*       payload = {}; // Function + function state
-
-    callable()
-        : invoker {nullptr}
-        , cleanup {nullptr}
-        , payload {nullptr}
-    {
-    }
+    callable()        = default;
 
     // Optimized path for simple function pointers (used by TTS_CASE)
     // Avoids template instantiation and heap allocation for stateless tests
-    callable(void (*f)()) // NOSONAR
-        : invoker {invoke_ptr}
-        , cleanup {cleanup_ptr}
-        , payload {reinterpret_cast<void*>(f)}
+    callable(void (*f)())                                               // NOSONAR
+        : erased_storage {reinterpret_cast<void*>(f), &destroy_nothing} // NOSONAR Type erasure
+        , invoker {invoke_ptr}
     {
     }
 
     // Copy/transfer the function as the unknown payload holding states
-    // We could have have used std::any but you know, compile-time
     template<typename Function>
-    callable(Function f) // NOSONAR
-        : invoker {invoke<Function>}
-        , cleanup {destroy<Function>}
-        , payload {new Function {TTS_MOVE(f)}} // NOSONAR Type erasure
+    callable(Function f)                                                  // NOSONAR
+        : erased_storage {new Function {TTS_MOVE(f)}, &destroy<Function>} // NOSONAR Type erasure
+        , invoker {invoke<Function>}
     {
     }
 
-    constexpr callable(callable&& other) noexcept
-        : invoker {TTS_MOVE(other.invoker)}
-        , cleanup {TTS_MOVE(other.cleanup)}
-        , payload {TTS_MOVE(other.payload)}
+    callable(callable&& other) noexcept
+        : erased_storage {TTS_MOVE(other)}
+        , invoker {other.invoker}
     {
-      other.payload = {};
     }
-
-    ~callable()
-    {
-      if(payload) cleanup(payload);
-    }
-
-    callable(callable const&)            = delete;
-    callable& operator=(callable const&) = delete;
 
     callable& operator=(callable&& other) noexcept
     {
-      payload       = TTS_MOVE(other.payload);
-      other.payload = {};
-      invoker       = TTS_MOVE(other.invoker);
-      cleanup       = TTS_MOVE(other.cleanup);
-
+      erased_storage::operator=(TTS_MOVE(other));
+      invoker = other.invoker;
       return *this;
     }
 
-    void operator()()
-    {
-      assert(payload);
-      invoker(payload);
-    }
     void operator()() const
     {
       assert(payload);
       invoker(payload);
     }
 
-    explicit operator bool() const
-    {
-      return payload != nullptr;
-    }
+    signature_t invoker = nullptr;
 
   private:
     template<typename T>
@@ -94,20 +61,10 @@ namespace tts::_
     {
       (*static_cast<T*>(data))();
     }
-    template<typename T>
-    static void destroy(void* data) // NOSONAR Type erasure: no need for a more complex solution
-    {
-      delete static_cast<T*>(data); // NOSONAR Type erasure: delete is safe
-    }
 
-    // Static helpers for the function pointer path
-    static void invoke_ptr(void* data) // NOSONAR Type erasure: no need for a more complex solution
+    static void invoke_ptr(void* data) // NOSONAR Type erasure
     {
       reinterpret_cast<void (*)()>(data)(); // NOSONAR Type erasure
-    }
-    static void cleanup_ptr(void*) // NOSONAR Type erasure: no need for a more complex solution
-    {
-      // NOSONAR No cleanup needed for function pointers
     }
   };
 }

--- a/include/tts/tools/callable.hpp
+++ b/include/tts/tools/callable.hpp
@@ -12,7 +12,7 @@
 
 namespace tts::_
 {
-  struct callable : erased_storage
+  struct callable : erased_storage // NOSONAR - erased_storage owns the payload and destroys it
   {
     using signature_t = void (*)(void*);
 
@@ -46,8 +46,6 @@ namespace tts::_
       invoker = other.invoker;
       return *this;
     }
-
-    ~callable() = default;
 
     void operator()() const
     {

--- a/include/tts/tools/callable.hpp
+++ b/include/tts/tools/callable.hpp
@@ -47,6 +47,8 @@ namespace tts::_
       return *this;
     }
 
+    ~callable() = default;
+
     void operator()() const
     {
       assert(payload);

--- a/include/tts/tools/erased_storage.hpp
+++ b/include/tts/tools/erased_storage.hpp
@@ -11,11 +11,11 @@ namespace tts::_
 {
   struct erased_storage
   {
-    using cleanup_t  = void (*)(void*); // NOSONAR - erasing the type is what the void* is for
+    using cleanup_t  = void (*)(void*);
 
     erased_storage() = default;
 
-    erased_storage(void* data, cleanup_t how)
+    erased_storage(void* data, cleanup_t how) // NOSONAR - this is the erasure
         : payload {data}
         , cleanup {how}
     {

--- a/include/tts/tools/erased_storage.hpp
+++ b/include/tts/tools/erased_storage.hpp
@@ -11,7 +11,7 @@ namespace tts::_
 {
   struct erased_storage
   {
-    using cleanup_t  = void (*)(void*);
+    using cleanup_t  = void (*)(void*); // NOSONAR - erasing the type is what the void* is for
 
     erased_storage() = default;
 

--- a/include/tts/tools/erased_storage.hpp
+++ b/include/tts/tools/erased_storage.hpp
@@ -1,0 +1,68 @@
+//======================================================================================================================
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//======================================================================================================================
+#pragma once
+
+namespace tts::_
+{
+  struct erased_storage
+  {
+    using cleanup_t  = void (*)(void*);
+
+    erased_storage() = default;
+
+    erased_storage(void* data, cleanup_t how)
+        : payload {data}
+        , cleanup {how}
+    {
+    }
+
+    erased_storage(erased_storage&& other) noexcept
+        : payload {other.payload}
+        , cleanup {other.cleanup}
+    {
+      other.payload = nullptr;
+    }
+
+    erased_storage& operator=(erased_storage&& other) noexcept
+    {
+      if(payload) cleanup(payload);
+
+      payload       = other.payload;
+      cleanup       = other.cleanup;
+      other.payload = nullptr;
+
+      return *this;
+    }
+
+    erased_storage(erased_storage const&)            = delete;
+    erased_storage& operator=(erased_storage const&) = delete;
+
+    ~erased_storage()
+    {
+      if(payload) cleanup(payload);
+    }
+
+    explicit operator bool() const
+    {
+      return payload != nullptr;
+    }
+
+    template<typename T> static void destroy(void* data) // NOSONAR
+    {
+      delete static_cast<T*>(data); // NOSONAR Type erasure: delete is safe
+    }
+
+    static void destroy_nothing(void*) // NOSONAR
+    {
+      // Nothing to free.
+    }
+
+    void*     payload = nullptr;
+    cleanup_t cleanup = nullptr;
+  };
+}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -91,6 +91,13 @@ copa_glob_unit( QUIET PATTERN "unit/driver/*.cpp"
                 RELATIVE ${root} INTERFACE tts_test DEPENDENCIES unit.infrastructure.exe
               )
 
+## crash.cpp brings its own process down on purpose and always exits 1, so its verdict is the line
+## its handler prints. Under emscripten the guard is compiled out and 77 marks the test skipped.
+set_tests_properties( unit.driver.crash.exe
+                      PROPERTIES  SKIP_RETURN_CODE 77
+                                  PASS_REGULAR_EXPRESSION "CRASH ATTRIBUTION OK"
+                    )
+
 
 ##======================================================================================================================
 ## Test for TTS Documentation

--- a/test/unit/doc/abort_handler.cpp
+++ b/test/unit/doc/abort_handler.cpp
@@ -1,0 +1,19 @@
+//==================================================================================================
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#define TTS_MAIN
+#include <tts/tts.hpp>
+
+//! [snippet]
+TTS_CASE("Choosing what a crashed or stuck run does before exiting")
+{
+  auto previous =
+  tts::set_abort_handler([](int reason) { std::printf("tearing down after signal %d\n", reason); });
+
+  TTS_EXPECT_NOT(previous);
+};
+//! [snippet]

--- a/test/unit/doc/abort_handler.cpp
+++ b/test/unit/doc/abort_handler.cpp
@@ -7,12 +7,13 @@
 //==================================================================================================
 #define TTS_MAIN
 #include <tts/tts.hpp>
+#include <iostream>
 
 //! [snippet]
 TTS_CASE("Choosing what a crashed or stuck run does before exiting")
 {
-  auto previous =
-  tts::set_abort_handler([](int reason) { std::printf("tearing down after signal %d\n", reason); });
+  auto previous = tts::set_abort_handler(
+  [](int reason) { std::cout << "tearing down after signal " << reason << "\n"; });
 
   TTS_EXPECT_NOT(previous);
 };

--- a/test/unit/driver/crash.cpp
+++ b/test/unit/driver/crash.cpp
@@ -1,0 +1,74 @@
+//==================================================================================================
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//==================================================================================================
+#define TTS_MAIN
+#define TTS_CUSTOM_DRIVER_FUNCTION crash_main
+#include <tts/tts.hpp>
+
+#if !defined(__EMSCRIPTEN__)
+#include <csignal>
+
+TTS_CASE("Case crashing halfway through")
+{
+  TTS_EXPECT(true);
+
+  // A raised signal keeps memcheck and the sanitizers silent: no invalid access happens.
+  std::raise(SIGSEGV);
+};
+
+namespace
+{
+  struct recording_sink : tts::output_sink
+  {
+    void write(tts::text const& t) override
+    {
+      seen += t;
+    }
+
+    void suite_aborted() override
+    {
+      aborted = true;
+    }
+
+    bool says(char const* what) const
+    {
+      return std::strstr(seen.data(), what) != nullptr;
+    }
+
+    tts::text seen    = {};
+    bool      aborted = false;
+  };
+}
+#endif
+
+int main([[maybe_unused]] int argc, [[maybe_unused]] char const** argv)
+{
+#if defined(__EMSCRIPTEN__)
+  return 77; // no crash guard here, so nothing to check
+#else
+  ::tts::initialize(argc, argv);
+
+  // main is still on the stack when the handler runs, so the capture stays valid.
+  recording_sink sink;
+
+  tts::set_abort_handler(
+  [ &sink ](int reason)
+  {
+    bool ok = reason == SIGSEGV && sink.aborted && sink.says("@@ CRASHED @@") &&
+              sink.says("SIGSEGV") && sink.says("Case crashing halfway through") &&
+              sink.says("Results:");
+
+    // The run exits 1 whatever happens, so ctest reads this line instead of the code.
+    if(ok) std::puts("CRASH ATTRIBUTION OK");
+  });
+
+  tts::scoped_sink scope(sink);
+  crash_main(argc, argv);
+
+  return 1; // the case above must not let us reach this
+#endif
+}

--- a/test/unit/driver/crash.cpp
+++ b/test/unit/driver/crash.cpp
@@ -58,9 +58,12 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char const** argv)
   tts::set_abort_handler(
   [ &sink ](int reason)
   {
-    bool ok = reason == SIGSEGV && sink.aborted && sink.says("@@ CRASHED @@") &&
-              sink.says("SIGSEGV") && sink.says("Case crashing halfway through") &&
-              sink.says("Results:");
+    // One composed line, so the name, the marker and the cause must appear together: TTS prints
+    // the case name on its own when the case starts, and that must not be enough.
+    tts::text attribution {"'%s' - @@ CRASHED @@ %s", "Case crashing halfway through", "SIGSEGV"};
+
+    bool      ok =
+    reason == SIGSEGV && sink.aborted && sink.says(attribution.data()) && sink.says("Results:");
 
     // The run exits 1 whatever happens, so ctest reads this line instead of the code.
     if(ok) std::puts("CRASH ATTRIBUTION OK");

--- a/test/unit/driver/crash.cpp
+++ b/test/unit/driver/crash.cpp
@@ -36,7 +36,7 @@ namespace
 
     bool says(char const* what) const
     {
-      return std::strstr(seen.data(), what) != nullptr;
+      return std::strstr(seen.data(), what) != nullptr; // NOSONAR - contains() is C++23
     }
 
     tts::text seen    = {};

--- a/test/unit/infrastructure/callable.cpp
+++ b/test/unit/infrastructure/callable.cpp
@@ -19,7 +19,7 @@ void       outside_function()
   outside_data = 99;
 }
 
-inline int outside_reason = 0;
+inline int outside_reason = 0; // NOSONAR - the handler under test writes it
 void       outside_reporter(int reason)
 {
   outside_reason = reason;

--- a/test/unit/infrastructure/callable.cpp
+++ b/test/unit/infrastructure/callable.cpp
@@ -19,6 +19,12 @@ void       outside_function()
   outside_data = 99;
 }
 
+inline int outside_reason = 0;
+void       outside_reporter(int reason)
+{
+  outside_reason = reason;
+}
+
 TTS_CASE("Check callable using a function")
 {
   tts::_::callable f = outside_function;
@@ -38,6 +44,42 @@ TTS_CASE("Check callable using a lambda")
   TTS_EQUAL(k, 0);
   f();
   TTS_EQUAL(k, 1);
+};
+
+TTS_CASE("Check abort_handler carries its int")
+{
+  tts::_::abort_handler empty;
+  TTS_EXPECT(!empty);
+
+  tts::_::abort_handler from_function = outside_reporter;
+  TTS_EXPECT(!!from_function);
+  from_function(11);
+  TTS_EQUAL(outside_reason, 11);
+
+  int                   seen        = 0;
+  tts::_::abort_handler from_lambda = [ & ](int reason) { seen = reason; };
+
+  from_lambda(6);
+  TTS_EQUAL(seen, 6);
+  from_lambda(9);
+  TTS_EQUAL(seen, 9);
+};
+
+TTS_CASE("Check abort_handler is movable only")
+{
+  int                   seen = 0;
+  tts::_::abort_handler f    = [ & ](int reason) { seen = reason; };
+  tts::_::abort_handler g;
+
+  TTS_EXPECT_NOT_COMPILES(f, g, { g = f; });
+  TTS_EXPECT_NOT_COMPILES(f, { tts::_::abort_handler(f); });
+
+  g = TTS_MOVE(f);
+
+  TTS_EXPECT(!!g);
+  TTS_EXPECT(!f);
+  g(4);
+  TTS_EQUAL(seen, 4);
 };
 
 TTS_CASE("Check callable is movable only")


### PR DESCRIPTION
A crashed test case cannot resume, so the driver arms a guard around each case, names the case in
the report the sinks already receive, and exits with 1. The guard covers SIGSEGV, SIGBUS, SIGFPE,
SIGILL and SIGABRT, and their Windows equivalents. `tts::set_abort_handler` takes a `void(int)`
receiving the signal, or 0 when nothing did, for a binary that has to handle an abrupt stop in its
own way. `--no-crash-guard`, or `TTS_NO_CRASH_GUARD` in the environment, leaves the signals to the
system, which is what a debugger or a sanitizer stack trace needs.
