### PR TITLE
Name the durations and the counters

### DIFF
--- a/include/tts/engine/case.hpp
+++ b/include/tts/engine/case.hpp
@@ -29,17 +29,17 @@ namespace tts::_
     capture(tagged_id id) // NOSONAR
         : name(id.name)
         , tag(id.tag)
-        , timeout_ms(id.timeout_ms)
+        , timeout_ns(id.timeout_ns)
         , timeout_set(id.timeout_set)
     {
     }
     auto operator+(auto body) const
     {
-      return test::acknowledge({name, body, /*types=*/ {}, tag, timeout_ms, timeout_set});
+      return test::acknowledge({name, body, /*types=*/ {}, tag, timeout_ns, timeout_set});
     }
     char const*             name;
     ::tts::expected_outcome tag         = ::tts::expected_outcome::pass;
-    milliseconds            timeout_ms  = 0;
+    nanoseconds             timeout_ns  = 0;
     bool                    timeout_set = false;
   };
 
@@ -73,7 +73,7 @@ namespace tts::_
     captures(tagged_id id) // NOSONAR
         : name(id.name)
         , tag(id.tag)
-        , timeout_ms(id.timeout_ms)
+        , timeout_ns(id.timeout_ns)
         , timeout_set(id.timeout_set)
     {
     }
@@ -100,12 +100,12 @@ namespace tts::_
        },
        joined_type_names<Types...>(),
        tag,
-       timeout_ms,
+       timeout_ns,
        timeout_set});
     }
     char const*             name;
     ::tts::expected_outcome tag         = ::tts::expected_outcome::pass;
-    milliseconds            timeout_ms  = 0;
+    nanoseconds             timeout_ns  = 0;
     bool                    timeout_set = false;
   };
 
@@ -128,7 +128,7 @@ namespace tts::_
   {
     char const*             name;
     ::tts::expected_outcome tag         = ::tts::expected_outcome::pass;
-    milliseconds            timeout_ms  = 0;
+    nanoseconds             timeout_ns  = 0;
     bool                    timeout_set = false;
 
     test_generators(char const* id) // NOSONAR
@@ -138,7 +138,7 @@ namespace tts::_
     test_generators(tagged_id id) // NOSONAR
         : name(id.name)
         , tag(id.tag)
-        , timeout_ms(id.timeout_ms)
+        , timeout_ns(id.timeout_ns)
         , timeout_set(id.timeout_set)
     {
     }
@@ -165,7 +165,7 @@ namespace tts::_
                                 },
                                 joined_type_names<Type...>(),
                                 tg.tag,
-                                tg.timeout_ms,
+                                tg.timeout_ns,
                                 tg.timeout_set});
     }
   };

--- a/include/tts/engine/environment.hpp
+++ b/include/tts/engine/environment.hpp
@@ -46,7 +46,7 @@ namespace tts::_
       unexpected_count++;
     }
 
-    int report(unsigned long long fails, unsigned long long invalids) const
+    int report(counter fails, counter invalids) const
     {
       auto  test_txt = test_count > 1 ? "s" : "";
       auto  pass_txt = success_count > 1 ? "es" : "";
@@ -105,14 +105,14 @@ namespace tts::_
       else return (failure_count == fails && invalid_count == invalids) ? 0 : 1;
     }
 
-    unsigned long long test_count        = 0;
-    unsigned long long success_count     = 0;
-    unsigned long long failure_count     = 0;
-    unsigned long long fatal_count       = 0;
-    unsigned long long invalid_count     = 0;
-    unsigned long long unexpected_count  = 0;
-    unsigned long long total_duration_ns = 0;
-    bool               fail_status       = false;
+    counter     test_count        = 0;
+    counter     success_count     = 0;
+    counter     failure_count     = 0;
+    counter     fatal_count       = 0;
+    counter     invalid_count     = 0;
+    counter     unexpected_count  = 0;
+    nanoseconds total_duration_ns = 0;
+    bool        fail_status       = false;
   };
 }
 
@@ -136,7 +136,7 @@ namespace tts
     @return 0 if all tests passed and 1 otherwise.
   **/
   //====================================================================================================================
-  inline int report(unsigned long long fails, unsigned long long invalids)
+  inline int report(counter fails, counter invalids)
   {
     return global_runtime.report(fails, invalids);
   }

--- a/include/tts/engine/main.hpp
+++ b/include/tts/engine/main.hpp
@@ -247,7 +247,7 @@ int TTS_CUSTOM_DRIVER_FUNCTION([[maybe_unused]] int argc, [[maybe_unused]] char 
       {
         [[maybe_unused]] ::tts::_::crash_guard guard {};
         [[maybe_unused]] ::tts::_::watchdog    deadline {
-        t.timeout_set ? t.timeout_ms : ::tts::_::default_timeout_ms()};
+        t.timeout_set ? t.timeout_ns : ::tts::_::default_timeout_ns()};
         t();
       }
       auto duration_ns = ::tts::_::now_ns() - start_ns;

--- a/include/tts/engine/test.hpp
+++ b/include/tts/engine/test.hpp
@@ -33,7 +33,6 @@ namespace tts
 
 namespace tts::_
 {
-  // A case deadline, in milliseconds.
 
   inline char const* current_test = "";
 
@@ -42,7 +41,7 @@ namespace tts::_
   {
     char const*             name;
     ::tts::expected_outcome tag;
-    milliseconds            timeout_ms  = 0;
+    nanoseconds             timeout_ns  = 0;
     bool                    timeout_set = false;
   };
 
@@ -72,7 +71,7 @@ namespace tts::_
     tts::_::callable        behaviour;
     tts::text               types       = {};
     ::tts::expected_outcome tag         = ::tts::expected_outcome::pass;
-    milliseconds            timeout_ms  = 0;
+    nanoseconds             timeout_ns  = 0;
     bool                    timeout_set = false;
   };
 
@@ -101,7 +100,7 @@ namespace tts
   /// Tags an already tagged ID as expected to fail, keeping whatever deadline it carries.
   inline _::tagged_id expect_fail(_::tagged_id const& id)
   {
-    return {id.name, expected_outcome::xfail, id.timeout_ms, id.timeout_set};
+    return {id.name, expected_outcome::xfail, id.timeout_ns, id.timeout_set};
   }
 
   /// Tags a @ref TTS_CASE's ID as allowed to pass or fail - see @ref TTS_MAYFAIL.
@@ -113,7 +112,7 @@ namespace tts
   /// Tags an already tagged ID as allowed to fail, keeping whatever deadline it carries.
   inline _::tagged_id may_fail(_::tagged_id const& id)
   {
-    return {id.name, expected_outcome::may_fail, id.timeout_ms, id.timeout_set};
+    return {id.name, expected_outcome::may_fail, id.timeout_ns, id.timeout_set};
   }
 
   /// Tags a @ref TTS_CASE's ID as expected to be empty - see @ref TTS_XINVALID.
@@ -125,18 +124,18 @@ namespace tts
   /// Tags an already tagged ID as expected to be empty, keeping whatever deadline it carries.
   inline _::tagged_id expect_invalid(_::tagged_id const& id)
   {
-    return {id.name, expected_outcome::xinvalid, id.timeout_ms, id.timeout_set};
+    return {id.name, expected_outcome::xinvalid, id.timeout_ns, id.timeout_set};
   }
 
   /// Gives a @ref TTS_CASE's ID a deadline in milliseconds - see @ref TTS_TIMEOUT.
-  inline _::tagged_id with_timeout(milliseconds ms, char const* id)
+  inline _::tagged_id with_timeout(unsigned long long ms, char const* id)
   {
-    return {id, expected_outcome::pass, ms, true};
+    return {id, expected_outcome::pass, ms * 1'000'000, true};
   }
 
   /// Gives an already tagged ID a deadline, keeping its tag - see @ref TTS_TIMEOUT.
-  inline _::tagged_id with_timeout(milliseconds ms, _::tagged_id const& id)
+  inline _::tagged_id with_timeout(unsigned long long ms, _::tagged_id const& id)
   {
-    return {id.name, id.tag, ms, true};
+    return {id.name, id.tag, ms * 1'000'000, true};
   }
 }

--- a/include/tts/engine/test.hpp
+++ b/include/tts/engine/test.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <tts/tools/buffer.hpp>
+#include <tts/tools/clock.hpp>
 #include <tts/tools/erased.hpp>
 #include <tts/tools/text.hpp>
 
@@ -33,7 +34,6 @@ namespace tts
 namespace tts::_
 {
   // A case deadline, in milliseconds.
-  using milliseconds              = unsigned long long;
 
   inline char const* current_test = "";
 
@@ -129,13 +129,13 @@ namespace tts
   }
 
   /// Gives a @ref TTS_CASE's ID a deadline in milliseconds - see @ref TTS_TIMEOUT.
-  inline _::tagged_id with_timeout(_::milliseconds ms, char const* id)
+  inline _::tagged_id with_timeout(milliseconds ms, char const* id)
   {
     return {id, expected_outcome::pass, ms, true};
   }
 
   /// Gives an already tagged ID a deadline, keeping its tag - see @ref TTS_TIMEOUT.
-  inline _::tagged_id with_timeout(_::milliseconds ms, _::tagged_id const& id)
+  inline _::tagged_id with_timeout(milliseconds ms, _::tagged_id const& id)
   {
     return {id.name, id.tag, ms, true};
   }

--- a/include/tts/engine/watchdog.hpp
+++ b/include/tts/engine/watchdog.hpp
@@ -25,18 +25,19 @@
 
 namespace tts::_
 {
-  inline milliseconds watchdog_ms = 0; // NOSONAR - the loop sets it before each case
+  inline nanoseconds watchdog_ns = 0; // NOSONAR - the loop sets it before each case
 
-  inline milliseconds default_timeout_ms()
+  inline nanoseconds default_timeout_ns()
   {
-    static milliseconds that = ::tts::arguments().value<milliseconds>("--timeout");
+    static nanoseconds that = ::tts::arguments().value<unsigned long long>("--timeout") * 1'000'000;
     return that;
   }
 
   inline void report_timeout()
   {
-    ::tts::text line {
-    "TEST: '%s' - @@ TIMEOUT @@ still running after %llu ms", current_test, watchdog_ms};
+    ::tts::text line {"TEST: '%s' - @@ TIMEOUT @@ still running after %s",
+                      current_test,
+                      format_duration(static_cast<double>(watchdog_ns)).data()};
 
     report_abort(line.data(), "TIMEOUT");
   }
@@ -48,7 +49,7 @@ namespace tts::_
   // No process-wide timer here: nothing to arm.
   struct watchdog
   {
-    explicit watchdog(milliseconds)
+    explicit watchdog(nanoseconds)
     {
     }
   };
@@ -68,16 +69,16 @@ namespace tts::_
 
   struct watchdog
   {
-    explicit watchdog(milliseconds ms)
+    explicit watchdog(nanoseconds ns)
     {
-      if(!ms) return;
+      if(!ns) return;
 
-      watchdog_ms = ms;
+      watchdog_ns = ns;
       CreateTimerQueueTimer(&timer_,
                             nullptr,
                             &watchdog_expired,
                             nullptr,
-                            static_cast<DWORD>(ms),
+                            static_cast<DWORD>(ns / 1'000'000u),
                             0,
                             WT_EXECUTEINTIMERTHREAD);
     }
@@ -113,11 +114,11 @@ namespace tts::_
 {
   struct watchdog
   {
-    explicit watchdog(milliseconds ms)
+    explicit watchdog(nanoseconds ns)
     {
-      if(!ms) return;
+      if(!ns) return;
 
-      watchdog_ms             = ms;
+      watchdog_ns             = ns;
 
       struct sigaction action = {};
       action.sa_handler       = &tts_watchdog_expired;
@@ -127,8 +128,8 @@ namespace tts::_
 
       // A thread blocked in a syscall still takes the signal, which a polling thread would not.
       itimerval deadline {};
-      deadline.it_value.tv_sec  = static_cast<time_t>(ms / 1000u);
-      deadline.it_value.tv_usec = static_cast<suseconds_t>((ms % 1000u) * 1000u);
+      deadline.it_value.tv_sec  = static_cast<time_t>(ns / 1'000'000'000u);
+      deadline.it_value.tv_usec = static_cast<suseconds_t>((ns % 1'000'000'000u) / 1000u);
       setitimer(ITIMER_REAL, &deadline, nullptr);
 
       armed_ = true;

--- a/include/tts/sinks/colorized.hpp
+++ b/include/tts/sinks/colorized.hpp
@@ -81,25 +81,25 @@ namespace tts
       set_color("\033[31m"); // red - NOSONAR, \o{} is C++23-only
     }
 
-    void test_finished([[maybe_unused]] text const&        name,
-                       bool                                passed,
-                       bool                                invalid,
-                       [[maybe_unused]] unsigned long long duration_ns) override
+    void test_finished([[maybe_unused]] text const& name,
+                       bool                         passed,
+                       bool                         invalid,
+                       [[maybe_unused]] nanoseconds duration_ns) override
     {
       if(invalid) set_color("\033[33m");     // yellow - NOSONAR, \o{} is C++23-only
       else if(passed) set_color("\033[32m"); // green - NOSONAR, \o{} is C++23-only
       else set_color(nullptr); // plain failure - assertion_failed() already colored its line
     }
 
-    void suite_finished([[maybe_unused]] unsigned long long fail_count,
-                        [[maybe_unused]] unsigned long long invalid_count) override
+    void suite_finished([[maybe_unused]] counter fail_count,
+                        [[maybe_unused]] counter invalid_count) override
     {
       set_color("\033[1m"); // bold, neutral - NOSONAR, \o{} is C++23-only
     }
 
-    void suite_metric(outcome                             kind,
-                      [[maybe_unused]] unsigned long long count,
-                      [[maybe_unused]] unsigned long long total) override
+    void suite_metric(outcome                  kind,
+                      [[maybe_unused]] counter count,
+                      [[maybe_unused]] counter total) override
     {
       using enum outcome;
       revert_to_ = active_color_; // fall back to this once the segment below is written

--- a/include/tts/sinks/json.hpp
+++ b/include/tts/sinks/json.hpp
@@ -103,10 +103,8 @@ namespace tts
                                  fatal ? "true" : "false"};
     }
 
-    void test_finished(text const&        name,
-                       bool               passed,
-                       bool               invalid,
-                       unsigned long long duration_ns) override
+    void
+    test_finished(text const& name, bool passed, bool invalid, nanoseconds duration_ns) override
     {
       char const* status = "failed";
       if(invalid)
@@ -135,7 +133,7 @@ namespace tts
     /// Renders everything gathered so far as a single JSON document.
     text render() const
     {
-      unsigned long long total = passed_count_ + failed_count_ + invalid_count_;
+      counter total = passed_count_ + failed_count_ + invalid_count_;
       return text {R"({"tests":[%s],"summary":{"total":%llu,"passed":%llu,"failed":%llu,)"
                    R"("invalid":%llu,"duration_ns":%llu}})",
                    body_.data(),
@@ -178,13 +176,13 @@ namespace tts
     }
 
   private:
-    output_sink*       target_;
-    text               body_;
-    text               current_failures_;
-    unsigned long long passed_count_      = 0;
-    unsigned long long failed_count_      = 0;
-    unsigned long long invalid_count_     = 0;
-    unsigned long long total_duration_ns_ = 0;
+    output_sink* target_;
+    text         body_;
+    text         current_failures_;
+    counter      passed_count_      = 0;
+    counter      failed_count_      = 0;
+    counter      invalid_count_     = 0;
+    nanoseconds  total_duration_ns_ = 0;
   };
 }
 

--- a/include/tts/sinks/junit.hpp
+++ b/include/tts/sinks/junit.hpp
@@ -93,10 +93,8 @@ namespace tts
       if(first_failure_.is_empty()) first_failure_ = _::xml_escape(message);
     }
 
-    void test_finished(text const&        name,
-                       bool               passed,
-                       bool               invalid,
-                       unsigned long long duration_ns) override
+    void
+    test_finished(text const& name, bool passed, bool invalid, nanoseconds duration_ns) override
     {
       if(invalid) ++invalid_count_;
       else if(passed) ++passed_count_;
@@ -141,8 +139,8 @@ namespace tts
     /// Renders everything gathered so far as a single JUnit XML document.
     text render() const
     {
-      unsigned long long total   = passed_count_ + failed_count_ + invalid_count_;
-      double             seconds = static_cast<double>(total_duration_ns_) / 1'000'000'000.0;
+      counter total   = passed_count_ + failed_count_ + invalid_count_;
+      double  seconds = static_cast<double>(total_duration_ns_) / 1'000'000'000.0;
 
       return text {"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                    R"(<testsuites><testsuite name="TTS" tests="%llu" failures="%llu" errors="0")"
@@ -188,13 +186,13 @@ namespace tts
     }
 
   private:
-    output_sink*       target_;
-    text               body_;
-    text               current_failures_;
-    text               first_failure_;
-    unsigned long long passed_count_      = 0;
-    unsigned long long failed_count_      = 0;
-    unsigned long long invalid_count_     = 0;
-    unsigned long long total_duration_ns_ = 0;
+    output_sink* target_;
+    text         body_;
+    text         current_failures_;
+    text         first_failure_;
+    counter      passed_count_      = 0;
+    counter      failed_count_      = 0;
+    counter      invalid_count_     = 0;
+    nanoseconds  total_duration_ns_ = 0;
   };
 }

--- a/include/tts/sinks/tap.hpp
+++ b/include/tts/sinks/tap.hpp
@@ -50,10 +50,10 @@ namespace tts
       // Intentionally empty: TAP output is built entirely from test_finished() below.
     }
 
-    void test_finished(text const&                         name,
-                       bool                                passed,
-                       [[maybe_unused]] bool               invalid,
-                       [[maybe_unused]] unsigned long long duration_ns) override
+    void test_finished(text const&                  name,
+                       bool                         passed,
+                       [[maybe_unused]] bool        invalid,
+                       [[maybe_unused]] nanoseconds duration_ns) override
     {
       ++count_;
       body_ += passed ? text {"ok %zu - %s\n", count_, name.data()}

--- a/include/tts/tools/clock.hpp
+++ b/include/tts/tools/clock.hpp
@@ -18,24 +18,25 @@
 #endif
 
 #include <tts/tools/text.hpp>
+#include <tts/tools/units.hpp>
 
 namespace tts::_
 {
   // Monotonic elapsed-time only, not std::chrono - see doc/compile_time.hpp.
-  inline unsigned long long now_ns()
+  inline nanoseconds now_ns()
   {
 #if defined(_WIN32)
     LARGE_INTEGER freq;
     LARGE_INTEGER count;
     QueryPerformanceFrequency(&freq);
     QueryPerformanceCounter(&count);
-    return static_cast<unsigned long long>(static_cast<double>(count.QuadPart) * 1e9 /
-                                           static_cast<double>(freq.QuadPart));
+    return static_cast<nanoseconds>(static_cast<double>(count.QuadPart) * 1e9 /
+                                    static_cast<double>(freq.QuadPart));
 #else
     struct timespec ts;
     clock_gettime(CLOCK_MONOTONIC, &ts); // NOSONAR - avoiding <chrono>, see comment above
-    return static_cast<unsigned long long>(ts.tv_sec) * 1'000'000'000ULL +
-           static_cast<unsigned long long>(ts.tv_nsec);
+    return static_cast<nanoseconds>(ts.tv_sec) * 1'000'000'000ULL +
+           static_cast<nanoseconds>(ts.tv_nsec);
 #endif
   }
 

--- a/include/tts/tools/output.hpp
+++ b/include/tts/tools/output.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <tts/tools/text.hpp>
+#include <tts/tools/units.hpp>
 
 namespace tts::_
 {
@@ -137,27 +138,27 @@ namespace tts
     /// Called once a @ref TTS_CASE / @ref TTS_CASE_TPL / @ref TTS_CASE_WITH has finished
     /// running, always and before its corresponding text (if any - suppressed under -q), with
     /// its outcome and how long it took to run, in nanoseconds. No-op by default.
-    virtual void test_finished([[maybe_unused]] text const&        name,
-                               [[maybe_unused]] bool               passed,
-                               [[maybe_unused]] bool               invalid,
-                               [[maybe_unused]] unsigned long long duration_ns)
+    virtual void test_finished([[maybe_unused]] text const& name,
+                               [[maybe_unused]] bool        passed,
+                               [[maybe_unused]] bool        invalid,
+                               [[maybe_unused]] nanoseconds duration_ns)
     {
       // Intentionally empty: most sinks only care about the formatted text stream.
     }
 
     /// Called once the whole suite has finished running (from tts::report()), with its aggregate
     /// outcome, always - even under -q. No-op by default.
-    virtual void suite_finished([[maybe_unused]] unsigned long long fail_count,
-                                [[maybe_unused]] unsigned long long invalid_count)
+    virtual void suite_finished([[maybe_unused]] counter fail_count,
+                                [[maybe_unused]] counter invalid_count)
     {
       // Intentionally empty: most sinks only care about the formatted text stream.
     }
 
     /// Called once per non-zero outcome category, right before its "N/M (P%) <label>" segment is
     /// printed as part of the `Results: ...` summary. No-op by default.
-    virtual void suite_metric([[maybe_unused]] outcome            kind,
-                              [[maybe_unused]] unsigned long long count,
-                              [[maybe_unused]] unsigned long long total)
+    virtual void suite_metric([[maybe_unused]] outcome kind,
+                              [[maybe_unused]] counter count,
+                              [[maybe_unused]] counter total)
     {
       // Intentionally empty: most sinks only care about the formatted text stream.
     }
@@ -346,19 +347,19 @@ namespace tts
     }
 
     /// Notifies the current output_sink that a test has finished running.
-    void test_finished(text const& name, bool passed, bool invalid, unsigned long long duration_ns)
+    void test_finished(text const& name, bool passed, bool invalid, nanoseconds duration_ns)
     {
       sink_->test_finished(name, passed, invalid, duration_ns);
     }
 
     /// Notifies the current output_sink that the whole suite has finished running.
-    void suite_finished(unsigned long long fail_count, unsigned long long invalid_count)
+    void suite_finished(counter fail_count, counter invalid_count)
     {
       sink_->suite_finished(fail_count, invalid_count);
     }
 
     /// Notifies the current output_sink that a Results: outcome category is about to print.
-    void suite_metric(outcome kind, unsigned long long count, unsigned long long total)
+    void suite_metric(outcome kind, counter count, counter total)
     {
       sink_->suite_metric(kind, count, total);
     }

--- a/include/tts/tools/units.hpp
+++ b/include/tts/tools/units.hpp
@@ -1,0 +1,18 @@
+//======================================================================================================================
+/*
+  TTS - Tiny Test System
+  Copyright : TTS Contributors & Maintainers
+  SPDX-License-Identifier: BSL-1.0
+*/
+//======================================================================================================================
+#pragma once
+
+namespace tts
+{
+  // An elapsed time and a deadline, each in its own unit, neither a std::chrono type.
+  using nanoseconds  = unsigned long long;
+  using milliseconds = unsigned long long;
+
+  // How many tests, failures, invalids: everything the suite tallies.
+  using counter = unsigned long long;
+}

--- a/include/tts/tools/units.hpp
+++ b/include/tts/tools/units.hpp
@@ -9,9 +9,8 @@
 
 namespace tts
 {
-  // An elapsed time and a deadline, each in its own unit, neither a std::chrono type.
-  using nanoseconds  = unsigned long long;
-  using milliseconds = unsigned long long;
+  // Every duration in the library, deadlines included. Not a std::chrono type.
+  using nanoseconds = unsigned long long;
 
   // How many tests, failures, invalids: everything the suite tallies.
   using counter = unsigned long long;

--- a/test/unit/driver/structured_sink.cpp
+++ b/test/unit/driver/structured_sink.cpp
@@ -46,10 +46,10 @@ namespace
       (void)location;
     }
 
-    void test_finished(tts::text const&   name,
-                       bool               passed,
-                       bool               invalid,
-                       unsigned long long duration_ns) override
+    void test_finished(tts::text const& name,
+                       bool             passed,
+                       bool             invalid,
+                       tts::nanoseconds duration_ns) override
     {
       // Sane upper bound (under 10s), not an exact value - actual timing is inherently
       // machine-dependent and would make this test flaky.
@@ -61,7 +61,7 @@ namespace
                               sane ? 1 : 0};
     }
 
-    void suite_finished(unsigned long long fail_count, unsigned long long invalid_count) override
+    void suite_finished(tts::counter fail_count, tts::counter invalid_count) override
     {
       log += tts::text {"SUITE_FINISHED fails=%llu invalids=%llu\n", fail_count, invalid_count};
     }

--- a/test/unit/driver/timeout.cpp
+++ b/test/unit/driver/timeout.cpp
@@ -36,8 +36,8 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char const** argv)
   [](int c, char const** v) { timeout_main(c, v); },
   [](tts::test::recording_sink const& sink, int reason)
   {
-    tts::text attribution {
-    "'%s' - @@ TIMEOUT @@ still running after %llu ms", "Case that never returns", 150ULL};
+    tts::text attribution {"'%s' - @@ TIMEOUT @@ still running after 150.000 ms",
+                           "Case that never returns"};
 
     return reason == 0 && sink.aborted && sink.says(attribution.data()) &&
            sink.says("ABORTING DUE TO TIMEOUT") && sink.says("Results:");


### PR DESCRIPTION
The three aliases sit in `tts`, not `tts::_`, because they appear in the virtual signatures a user's
own sink overrides. They live in a header that includes nothing, so `output.hpp` never has to pull
`clock.hpp` and its `<windows.h>` behind it. An alias is the same type, so nothing an existing sink
compiles against changes.
